### PR TITLE
'syzygy' => 'singularity'

### DIFF
--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -51,7 +51,7 @@ services:
       context: smtp
       dockerfile: Containerfile
       additional_contexts:
-        - TCP_SERVER_CONTAINER=container-image://localhost/syzygy_tcp_server:latest
+        - TCP_SERVER_CONTAINER=container-image://localhost/singularity_tcp_server:latest
       target: smtp
       args:
         hostname: localhost
@@ -64,7 +64,7 @@ services:
       context: pop
       dockerfile: Containerfile
       additional_contexts:
-        - TCP_SERVER_CONTAINER=container-image://localhost/syzygy_tcp_server:latest
+        - TCP_SERVER_CONTAINER=container-image://localhost/singularity_tcp_server:latest
       target: pop
     volumes:
       - ./email/mail:/mnt/mail:ro,z

--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -31,7 +31,7 @@ services:
     security_opt:
       - label:disable
     volumes:
-      - ./.git:/var/git/syzygy:ro,z
+      - ./.git:/var/git/singularity:ro,z
       - ./kdlp.underground.software:/orbit/docs:ro,z
     ports:
       - 9098:9098

--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -32,12 +32,6 @@ services:
       - label:disable
     volumes:
       - ./.git:/var/git/syzygy:ro,z
-      - ./.git/modules/orbit:/var/git/orbit:ro,z
-      - ./.git/modules/tcp_server:/var/git/tcp_server:ro,z
-      - ./.git/modules/pop:/var/git/pop:ro,z
-      - ./.git/modules/smtp:/var/git/smtp:ro,z
-      - ./.git/modules/extenginx:/var/git/extenginx:ro,z
-      - ./.git/modules/kdlp.underground.software:/var/git/kdlp.underground.software:ro,z
       - ./kdlp.underground.software:/orbit/docs:ro,z
     ports:
       - 9098:9098

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -42,7 +42,7 @@ services:
       context: smtp
       dockerfile: Containerfile
       additional_contexts:
-        - TCP_SERVER_CONTAINER=container-image://localhost/syzygy_tcp_server:latest
+        - TCP_SERVER_CONTAINER=container-image://localhost/singularity_tcp_server:latest
       target: smtp
       args:
         hostname: dev.underground.software
@@ -55,7 +55,7 @@ services:
       context: pop
       dockerfile: Containerfile
       additional_contexts:
-        - TCP_SERVER_CONTAINER=container-image://localhost/syzygy_tcp_server:latest
+        - TCP_SERVER_CONTAINER=container-image://localhost/singularity_tcp_server:latest
       target: pop
     volumes:
       - ./email/mail:/mnt/mail:ro,z

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -23,12 +23,6 @@ services:
       target: orbit
     volumes:
       - ./.git:/var/git/syzygy:ro,z
-      - ./.git/modules/orbit:/var/git/orbit:ro,z
-      - ./.git/modules/tcp_server:/var/git/tcp_server:ro,z
-      - ./.git/modules/pop:/var/git/pop:ro,z
-      - ./.git/modules/smtp:/var/git/smtp:ro,z
-      - ./.git/modules/extenginx:/var/git/extenginx:ro,z
-      - ./.git/modules/kdlp.underground.software:/var/git/kdlp.underground.software:ro,z
       - ./kdlp.underground.software:/orbit/docs:ro,z
     ports:
       - 9098:9098

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -22,7 +22,7 @@ services:
       dockerfile: Containerfile
       target: orbit
     volumes:
-      - ./.git:/var/git/syzygy:ro,z
+      - ./.git:/var/git/singularity:ro,z
       - ./kdlp.underground.software:/orbit/docs:ro,z
     ports:
       - 9098:9098

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -23,12 +23,6 @@ services:
       target: orbit
     volumes:
       - ./.git:/var/git/syzygy:ro,z
-      - ./.git/modules/orbit:/var/git/orbit:ro,z
-      - ./.git/modules/tcp_server:/var/git/tcp_server:ro,z
-      - ./.git/modules/pop:/var/git/pop:ro,z
-      - ./.git/modules/smtp:/var/git/smtp:ro,z
-      - ./.git/modules/extenginx:/var/git/extenginx:ro,z
-      - ./.git/modules/kdlp.underground.software:/var/git/kdlp.underground.software:ro,z
       - ./kdlp.underground.software:/orbit/docs:ro,z
     ports:
       - 9098:9098

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -42,7 +42,7 @@ services:
       context: smtp
       dockerfile: Containerfile
       additional_contexts:
-        - TCP_SERVER_CONTAINER=container-image://localhost/syzygy_tcp_server:latest
+        - TCP_SERVER_CONTAINER=container-image://localhost/singularity_tcp_server:latest
       target: smtp
       args:
         hostname: kdlp.underground.software
@@ -55,7 +55,7 @@ services:
       context: pop
       dockerfile: Containerfile
       additional_contexts:
-        - TCP_SERVER_CONTAINER=container-image://localhost/syzygy_tcp_server:latest
+        - TCP_SERVER_CONTAINER=container-image://localhost/singularity_tcp_server:latest
       target: pop
     volumes:
       - ./email/mail:/mnt/mail:ro,z

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -22,7 +22,7 @@ services:
       dockerfile: Containerfile
       target: orbit
     volumes:
-      - ./.git:/var/git/syzygy:ro,z
+      - ./.git:/var/git/singularity:ro,z
       - ./kdlp.underground.software:/orbit/docs:ro,z
     ports:
       - 9098:9098


### PR DESCRIPTION
Replace all references to the old name, and remove the old mount points from orbit that were used for the submodules. It is now possible to properly build the repo again.