### PR TITLE
pop/smtp/tcp_server general cleanup to remove dead code

### DIFF
--- a/pop/Containerfile
+++ b/pop/Containerfile
@@ -4,7 +4,7 @@ RUN apk add \
 	make \
 	;
 
-ADD . /pop
+COPY . /pop
 
 RUN make -C /pop CC='clang -static'
 

--- a/pop/Containerfile
+++ b/pop/Containerfile
@@ -10,8 +10,6 @@ RUN make -C /pop CC='clang -static'
 
 RUN mkdir -p /mnt/mail
 
-#FROM fedora:latest as smtp
-#RUN dnf -y update && dnf -y install libselinux-utils && dnf clean all
 FROM scratch as pop
 COPY --from=build /mnt/mail /mnt/mail
 VOLUME /mnt/mail

--- a/pop/Makefile
+++ b/pop/Makefile
@@ -1,7 +1,10 @@
 CC = clang
 CFLAGS = -std=c2x -Weverything -Wno-unsafe-buffer-usage -Wno-c++98-compat -Wno-gnu-designator -Wno-gnu-case-range -Wno-initializer-overrides \
 	-Wno-declaration-after-statement -Wno-four-char-constants -Wno-pre-c2x-compat -Wno-disabled-macro-expansion -D_GNU_SOURCE
-#CFLAGS += -DDEBUG -Og -g
+
+ifdef DEBUG
+	CFLAGS += -DDEBUG -Og -g
+endif
 
 .PHONY: all clean
 

--- a/smtp/Containerfile
+++ b/smtp/Containerfile
@@ -4,7 +4,7 @@ RUN apk add \
 	make \
 	;
 
-ADD . /smtp
+COPY . /smtp
 
 ARG hostname
 RUN test -n "$hostname" || (echo 'hostname is not set' && false)

--- a/smtp/Containerfile
+++ b/smtp/Containerfile
@@ -13,8 +13,6 @@ RUN make -C /smtp CC='clang -static' SRVNAME=$hostname
 
 RUN mkdir -p /mnt/email_data/mail /mnt/email_data/logs
 
-#FROM fedora:latest as smtp
-#RUN dnf -y update && dnf -y install libselinux-utils && dnf clean all
 FROM scratch as smtp
 COPY --from=build /mnt/email_data /mnt/email_data
 VOLUME /mnt/email_data/

--- a/smtp/Makefile
+++ b/smtp/Makefile
@@ -2,7 +2,11 @@ CC = clang
 CFLAGS = -std=c2x -Weverything -Wno-unsafe-buffer-usage -Wno-c++98-compat -Wno-gnu-designator \
 	-Wno-initializer-overrides -Wno-declaration-after-statement -Wno-four-char-constants \
 	-Wno-pre-c2x-compat -Wno-disabled-macro-expansion -D_GNU_SOURCE -DHOSTNAME='"$(SRVNAME)"'
-#CFLAGS += -DDEBUG -Og -g
+
+ifdef DEBUG
+	CFLAGS += -DDEBUG -Og -g
+endif
+
 .PHONY: all clean
 all: smtp
 

--- a/tcp_server/Containerfile
+++ b/tcp_server/Containerfile
@@ -4,7 +4,7 @@ RUN apk add \
 	make \
 	;
 
-ADD . /tcp_server
+COPY . /tcp_server
 
 RUN make -C /tcp_server CC='clang -static'
 

--- a/tcp_server/Makefile
+++ b/tcp_server/Makefile
@@ -1,7 +1,10 @@
 CC = clang
 CFLAGS = -std=c2x -Weverything -Wno-declaration-after-statement -Wno-c++98-compat -Wno-padded \
 	-Wno-unsafe-buffer-usage -Wno-disabled-macro-expansion -Wno-pre-c2x-compat -D_GNU_SOURCE
-#CFLAGS += -DDEBUG -Og -g
+
+ifdef DEBUG
+	CFLAGS += -DDEBUG -Og -g
+endif
 
 .PHONY: all clean
 


### PR DESCRIPTION
There are several places where artifacts of the development process (commented out lines of code, antiquated approaches, etc) made it into the master branch. This PR cleans them up.