### PR TITLE
Cleanup compose files

### DIFF
--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -34,19 +34,27 @@ services:
       - target: 1080
         published: 1080
         protocol: tcp
+        app_protocol: http
         mode: host
+        name: "port for http connections to proxy"
       - target: 1443
         published: 1443
         protocol: tcp
+        app_protocol: https
         mode: host
+        name: "port for https connections to proxy"
       - target: 1465
         published: 1465
         protocol: tcp
+        app_protocol: smtps
         mode: host
+        name: "port for smtps connections to proxy"
       - target: 1995
         published: 1995
         protocol: tcp
+        app_protocol: pop3s
         mode: host
+        name: "port for pop3s connections to proxy"
   orbit:
     build:
       context: orbit
@@ -69,7 +77,9 @@ services:
       - target: 9098
         published: 9098
         protocol: tcp
+        app_protocol: http
         mode: host
+        name: "unencrypted http upstream server port"
   smtp:
     build:
       context: smtp
@@ -89,7 +99,9 @@ services:
       - target: 465
         published: 11465
         protocol: tcp
+        app_protocol: smtp
         mode: host
+        name: "unencrypted smtp upstream server port"
   pop:
     build:
       context: pop
@@ -107,4 +119,6 @@ services:
       - target: 995
         published: 11995
         protocol: tcp
+        app_protocol: pop3
         mode: host
+        name: "unencrypted pop3 upstream server port"

--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -15,9 +15,21 @@ services:
     security_opt:
       - label:disable
     volumes:
-      - ./ssl:/etc/ssl/nginx:ro,z
-      - ./nginx_snippets:/etc/nginx/include.d:ro,z
-      - ./kdlp.underground.software:/var/www/html:ro,z
+      - type: bind
+        source: ./ssl
+        target: /etc/ssl/nginx
+        read_only: true
+        selinux: z
+      - type: bind
+        source: ./nginx_snippets
+        target: /etc/nginx/include.d
+        read_only: true
+        selinux: z
+      - type: bind
+        source: ./kdlp.underground.software
+        target: /var/www/html
+        read_only: true
+        selinux: z
     ports:
       - 1080:1080
       - 1443:1443
@@ -31,8 +43,16 @@ services:
     security_opt:
       - label:disable
     volumes:
-      - ./.git:/var/git/singularity:ro,z
-      - ./kdlp.underground.software:/orbit/docs:ro,z
+      - type: bind
+        source: ./.git
+        target: /var/git/singularity
+        read_only: true
+        selinux: z
+      - type: bind
+        source: ./kdlp.underground.software
+        target: /orbit/docs
+        read_only: true
+        selinux: z
     ports:
       - 9098:9098
   smtp:
@@ -45,7 +65,11 @@ services:
       args:
         hostname: localhost
     volumes:
-      - ./email:/mnt/email_data:z
+      - type: bind
+        source: ./email
+        target: /mnt/email_data
+        read_only: false
+        selinux: z
     ports:
       - 11465:465
   pop:
@@ -56,6 +80,10 @@ services:
         - TCP_SERVER_SOURCE=./tcp_server
       target: pop
     volumes:
-      - ./email/mail:/mnt/mail:ro,z
+      - type: bind
+        source: ./email/mail
+        target: /mnt/mail
+        read_only: true
+        selinux: z
     ports:
       - 11995:995

--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: Containerfile
       target: nginx
       args:
+        NGINX_HOSTNAME: localhost
         NGINX_HTTP_PORT: 1080
         NGINX_HTTPS_PORT: 1443
         NGINX_SMTPS_PORT: 1465

--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -31,10 +31,22 @@ services:
         read_only: true
         selinux: z
     ports:
-      - 1080:1080
-      - 1443:1443
-      - 1465:1465
-      - 1995:1995
+      - target: 1080
+        published: 1080
+        protocol: tcp
+        mode: host
+      - target: 1443
+        published: 1443
+        protocol: tcp
+        mode: host
+      - target: 1465
+        published: 1465
+        protocol: tcp
+        mode: host
+      - target: 1995
+        published: 1995
+        protocol: tcp
+        mode: host
   orbit:
     build:
       context: orbit
@@ -54,7 +66,10 @@ services:
         read_only: true
         selinux: z
     ports:
-      - 9098:9098
+      - target: 9098
+        published: 9098
+        protocol: tcp
+        mode: host
   smtp:
     build:
       context: smtp
@@ -71,7 +86,10 @@ services:
         read_only: false
         selinux: z
     ports:
-      - 11465:465
+      - target: 465
+        published: 11465
+        protocol: tcp
+        mode: host
   pop:
     build:
       context: pop
@@ -86,4 +104,7 @@ services:
         read_only: true
         selinux: z
     ports:
-      - 11995:995
+      - target: 995
+        published: 11995
+        protocol: tcp
+        mode: host

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -23,19 +23,27 @@ services:
       - target: 80
         published: 80
         protocol: tcp
+        app_protocol: http
         mode: host
+        name: "port for http connections to proxy"
       - target: 443
         published: 443
         protocol: tcp
+        app_protocol: https
         mode: host
+        name: "port for https connections to proxy"
       - target: 465
         published: 465
         protocol: tcp
+        app_protocol: smtps
         mode: host
+        name: "port for smtps connections to proxy"
       - target: 995
         published: 995
         protocol: tcp
+        app_protocol: pop3s
         mode: host
+        name: "port for pop3s connections to proxy"
   orbit:
     build:
       context: orbit
@@ -56,7 +64,9 @@ services:
       - target: 9098
         published: 9098
         protocol: tcp
+        app_protocol: http
         mode: host
+        name: "unencrypted http upstream server port"
   smtp:
     build:
       context: smtp
@@ -76,7 +86,9 @@ services:
       - target: 465
         published: 11465
         protocol: tcp
+        app_protocol: smtp
         mode: host
+        name: "unencrypted smtp upstream server port"
   pop:
     build:
       context: pop
@@ -94,4 +106,6 @@ services:
       - target: 995
         published: 11995
         protocol: tcp
+        app_protocol: pop3
         mode: host
+        name: "unencrypted pop3 upstream server port"

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -9,8 +9,16 @@ services:
       args:
         NGINX_HOSTNAME: dev.underground.software
     volumes:
-      - ./ssl:/etc/ssl/nginx:ro,z
-      - ./kdlp.underground.software:/var/www/html:ro,z
+      - type: bind
+        source: ./ssl
+        target: /etc/ssl/nginx
+        read_only: true
+        selinux: z
+      - type: bind
+        source: ./kdlp.underground.software
+        target: /var/www/html
+        read_only: true
+        selinux: z
     ports:
       - 80:80
       - 443:443
@@ -22,8 +30,16 @@ services:
       dockerfile: Containerfile
       target: orbit
     volumes:
-      - ./.git:/var/git/singularity:ro,z
-      - ./kdlp.underground.software:/orbit/docs:ro,z
+      - type: bind
+        source: ./.git
+        target: /var/git/singularity
+        read_only: true
+        selinux: z
+      - type: bind
+        source: ./kdlp.underground.software
+        target: /orbit/docs
+        read_only: true
+        selinux: z
     ports:
       - 9098:9098
   smtp:
@@ -36,7 +52,11 @@ services:
       args:
         hostname: dev.underground.software
     volumes:
-      - ./email:/mnt/email_data:z
+      - type: bind
+        source: ./email
+        target: /mnt/email_data
+        read_only: false
+        selinux: z
     ports:
       - 11465:465
   pop:
@@ -47,6 +67,10 @@ services:
         - TCP_SERVER_SOURCE=./tcp_server
       target: pop
     volumes:
-      - ./email/mail:/mnt/mail:ro,z
+      - type: bind
+        source: ./email/mail
+        target: /mnt/mail
+        read_only: true
+        selinux: z
     ports:
       - 11995:995

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -20,10 +20,22 @@ services:
         read_only: true
         selinux: z
     ports:
-      - 80:80
-      - 443:443
-      - 465:465
-      - 995:995
+      - target: 80
+        published: 80
+        protocol: tcp
+        mode: host
+      - target: 443
+        published: 443
+        protocol: tcp
+        mode: host
+      - target: 465
+        published: 465
+        protocol: tcp
+        mode: host
+      - target: 995
+        published: 995
+        protocol: tcp
+        mode: host
   orbit:
     build:
       context: orbit
@@ -41,7 +53,10 @@ services:
         read_only: true
         selinux: z
     ports:
-      - 9098:9098
+      - target: 9098
+        published: 9098
+        protocol: tcp
+        mode: host
   smtp:
     build:
       context: smtp
@@ -58,7 +73,10 @@ services:
         read_only: false
         selinux: z
     ports:
-      - 11465:465
+      - target: 465
+        published: 11465
+        protocol: tcp
+        mode: host
   pop:
     build:
       context: pop
@@ -73,4 +91,7 @@ services:
         read_only: true
         selinux: z
     ports:
-      - 11995:995
+      - target: 995
+        published: 11995
+        protocol: tcp
+        mode: host

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -23,19 +23,27 @@ services:
       - target: 80
         published: 80
         protocol: tcp
+        app_protocol: http
         mode: host
+        name: "port for http connections to proxy"
       - target: 443
         published: 443
         protocol: tcp
+        app_protocol: https
         mode: host
+        name: "port for https connections to proxy"
       - target: 465
         published: 465
         protocol: tcp
+        app_protocol: smtps
         mode: host
+        name: "port for smtps connections to proxy"
       - target: 995
         published: 995
         protocol: tcp
+        app_protocol: pop3s
         mode: host
+        name: "port for pop3s connections to proxy"
   orbit:
     build:
       context: orbit
@@ -56,7 +64,9 @@ services:
       - target: 9098
         published: 9098
         protocol: tcp
+        app_protocol: http
         mode: host
+        name: "unencrypted http upstream server port"
   smtp:
     build:
       context: smtp
@@ -76,7 +86,9 @@ services:
       - target: 465
         published: 11465
         protocol: tcp
+        app_protocol: smtp
         mode: host
+        name: "unencrypted smtp upstream server port"
   pop:
     build:
       context: pop
@@ -94,4 +106,6 @@ services:
       - target: 995
         published: 11995
         protocol: tcp
+        app_protocol: pop3
         mode: host
+        name: "unencrypted pop3 upstream server port"

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -9,8 +9,16 @@ services:
       args:
         NGINX_HOSTNAME: kdlp.underground.software
     volumes:
-      - ./ssl:/etc/ssl/nginx:ro,z
-      - ./kdlp.underground.software:/var/www/html:ro,z
+      - type: bind
+        source: ./ssl
+        target: /etc/ssl/nginx
+        read_only: true
+        selinux: z
+      - type: bind
+        source: ./kdlp.underground.software
+        target: /var/www/html
+        read_only: true
+        selinux: z
     ports:
       - 80:80
       - 443:443
@@ -22,8 +30,16 @@ services:
       dockerfile: Containerfile
       target: orbit
     volumes:
-      - ./.git:/var/git/singularity:ro,z
-      - ./kdlp.underground.software:/orbit/docs:ro,z
+      - type: bind
+        source: ./.git
+        target: /var/git/singularity
+        read_only: true
+        selinux: z
+      - type: bind
+        source: ./kdlp.underground.software
+        target: /orbit/docs
+        read_only: true
+        selinux: z
     ports:
       - 9098:9098
   smtp:
@@ -36,7 +52,11 @@ services:
       args:
         hostname: kdlp.underground.software
     volumes:
-      - ./email:/mnt/email_data:z
+      - type: bind
+        source: ./email
+        target: /mnt/email_data
+        read_only: false
+        selinux: z
     ports:
       - 11465:465
   pop:
@@ -47,6 +67,10 @@ services:
         - TCP_SERVER_SOURCE=./tcp_server
       target: pop
     volumes:
-      - ./email/mail:/mnt/mail:ro,z
+      - type: bind
+        source: ./email/mail
+        target: /mnt/mail
+        read_only: true
+        selinux: z
     ports:
       - 11995:995

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -20,10 +20,22 @@ services:
         read_only: true
         selinux: z
     ports:
-      - 80:80
-      - 443:443
-      - 465:465
-      - 995:995
+      - target: 80
+        published: 80
+        protocol: tcp
+        mode: host
+      - target: 443
+        published: 443
+        protocol: tcp
+        mode: host
+      - target: 465
+        published: 465
+        protocol: tcp
+        mode: host
+      - target: 995
+        published: 995
+        protocol: tcp
+        mode: host
   orbit:
     build:
       context: orbit
@@ -41,7 +53,10 @@ services:
         read_only: true
         selinux: z
     ports:
-      - 9098:9098
+      - target: 9098
+        published: 9098
+        protocol: tcp
+        mode: host
   smtp:
     build:
       context: smtp
@@ -58,7 +73,10 @@ services:
         read_only: false
         selinux: z
     ports:
-      - 11465:465
+      - target: 465
+        published: 11465
+        protocol: tcp
+        mode: host
   pop:
     build:
       context: pop
@@ -73,4 +91,7 @@ services:
         read_only: true
         selinux: z
     ports:
-      - 11995:995
+      - target: 995
+        published: 11995
+        protocol: tcp
+        mode: host


### PR DESCRIPTION
Using the more verbose syntax for mounts and ports makes the compose files slightly longer, but splitting the specifications onto multiple lines of clear key/value pairs allows the compose to be self documenting and will make future changes easier by making merge conflicts easier to resolve since git is only smart enough to handle context in the form of full lines.

Depends on #23 