### PR TITLE
Use unprivileged ports within containers

### DIFF
--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -92,6 +92,7 @@ services:
       target: smtp
       args:
         hostname: localhost
+        LISTEN_PORT: 1465
     volumes:
       - type: bind
         source: ./email
@@ -99,7 +100,7 @@ services:
         read_only: false
         selinux: z
     ports:
-      - target: 465
+      - target: 1465
         published: 11465
         protocol: tcp
         app_protocol: smtp

--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -113,6 +113,8 @@ services:
       additional_contexts:
         - TCP_SERVER_SOURCE=./tcp_server
       target: pop
+      args:
+        LISTEN_PORT: 1995
     volumes:
       - type: bind
         source: ./email/mail
@@ -120,7 +122,7 @@ services:
         read_only: true
         selinux: z
     ports:
-      - target: 995
+      - target: 1995
         published: 11995
         protocol: tcp
         app_protocol: pop3

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -82,6 +82,7 @@ services:
       target: smtp
       args:
         hostname: dev.underground.software
+        LISTEN_PORT: 1465
     volumes:
       - type: bind
         source: ./email
@@ -89,7 +90,7 @@ services:
         read_only: false
         selinux: z
     ports:
-      - target: 465
+      - target: 1465
         published: 11465
         protocol: tcp
         app_protocol: smtp

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -103,6 +103,8 @@ services:
       additional_contexts:
         - TCP_SERVER_SOURCE=./tcp_server
       target: pop
+      args:
+        LISTEN_PORT: 1995
     volumes:
       - type: bind
         source: ./email/mail
@@ -110,7 +112,7 @@ services:
         read_only: true
         selinux: z
     ports:
-      - target: 995
+      - target: 1995
         published: 11995
         protocol: tcp
         app_protocol: pop3

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -8,6 +8,10 @@ services:
       target: nginx
       args:
         NGINX_HOSTNAME: dev.underground.software
+        NGINX_HTTP_PORT: 1080
+        NGINX_HTTPS_PORT: 1443
+        NGINX_SMTPS_PORT: 1465
+        NGINX_POP3S_PORT: 1995
     volumes:
       - type: bind
         source: ./ssl
@@ -20,25 +24,25 @@ services:
         read_only: true
         selinux: z
     ports:
-      - target: 80
+      - target: 1080
         published: 80
         protocol: tcp
         app_protocol: http
         mode: host
         name: "port for http connections to proxy"
-      - target: 443
+      - target: 1443
         published: 443
         protocol: tcp
         app_protocol: https
         mode: host
         name: "port for https connections to proxy"
-      - target: 465
+      - target: 1465
         published: 465
         protocol: tcp
         app_protocol: smtps
         mode: host
         name: "port for smtps connections to proxy"
-      - target: 995
+      - target: 1995
         published: 995
         protocol: tcp
         app_protocol: pop3s

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -8,6 +8,10 @@ services:
       target: nginx
       args:
         NGINX_HOSTNAME: kdlp.underground.software
+        NGINX_HTTP_PORT: 1080
+        NGINX_HTTPS_PORT: 1443
+        NGINX_SMTPS_PORT: 1465
+        NGINX_POP3S_PORT: 1995
     volumes:
       - type: bind
         source: ./ssl
@@ -20,25 +24,25 @@ services:
         read_only: true
         selinux: z
     ports:
-      - target: 80
+      - target: 1080
         published: 80
         protocol: tcp
         app_protocol: http
         mode: host
         name: "port for http connections to proxy"
-      - target: 443
+      - target: 1443
         published: 443
         protocol: tcp
         app_protocol: https
         mode: host
         name: "port for https connections to proxy"
-      - target: 465
+      - target: 1465
         published: 465
         protocol: tcp
         app_protocol: smtps
         mode: host
         name: "port for smtps connections to proxy"
-      - target: 995
+      - target: 1995
         published: 995
         protocol: tcp
         app_protocol: pop3s

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -103,6 +103,8 @@ services:
       additional_contexts:
         - TCP_SERVER_SOURCE=./tcp_server
       target: pop
+      args:
+        LISTEN_PORT: 1995
     volumes:
       - type: bind
         source: ./email/mail
@@ -110,7 +112,7 @@ services:
         read_only: true
         selinux: z
     ports:
-      - target: 995
+      - target: 1995
         published: 11995
         protocol: tcp
         app_protocol: pop3

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -82,6 +82,7 @@ services:
       target: smtp
       args:
         hostname: kdlp.underground.software
+        LISTEN_PORT: 1465
     volumes:
       - type: bind
         source: ./email
@@ -89,7 +90,7 @@ services:
         read_only: false
         selinux: z
     ports:
-      - target: 465
+      - target: 1465
         published: 11465
         protocol: tcp
         app_protocol: smtp


### PR DESCRIPTION
This is a nice step towards being able to run the code in the containers as a non root user for added security