### PR TITLE
orbit: switch production/dev toggle from environment to ARG

### DIFF
--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -61,6 +61,8 @@ services:
       context: orbit
       dockerfile: Containerfile
       target: orbit
+      args:
+        - PRODUCTION: false
     security_opt:
       - label:disable
     volumes:
@@ -81,8 +83,6 @@ services:
         app_protocol: http
         mode: host
         name: "unencrypted http upstream server port"
-    environment:
-      - PRODUCTION=false
   smtp:
     build:
       context: smtp

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -49,6 +49,8 @@ services:
       context: orbit
       dockerfile: Containerfile
       target: orbit
+      args:
+        - PRODUCTION: false
     volumes:
       - type: bind
         source: ./.git
@@ -60,8 +62,6 @@ services:
         target: /orbit/docs
         read_only: true
         selinux: z
-    environment:
-      - PRODUCTION=false
     ports:
       - target: 9098
         published: 9098

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -49,6 +49,8 @@ services:
       context: orbit
       dockerfile: Containerfile
       target: orbit
+      args:
+        - PRODUCTION: true
     volumes:
       - type: bind
         source: ./.git
@@ -67,8 +69,6 @@ services:
         app_protocol: http
         mode: host
         name: "unencrypted http upstream server port"
-    environment:
-      - PRODUCTION=true
   smtp:
     build:
       context: smtp

--- a/orbit/Containerfile
+++ b/orbit/Containerfile
@@ -33,4 +33,7 @@ COPY cgitrc /etc/cgitrc
 
 EXPOSE 9098
 
+ARG PRODUCTION
+ENV PRODUCTION=${PRODUCTION}
+
 CMD /bin/sh -c "source /radius-venv/bin/activate && uwsgi /orbit/radius.ini"


### PR DESCRIPTION
By passing the value as an environment variable in the compose file it trashes the cache of all layers because that environment variable has to be set for all commands in all layers and could affect their behavior. This forces the builder to re-run everything including installing packages, building pip wheels etc. Since there are only two values, it isn't so bad -- once you have built with each at least once you will have a cache of both, but there is no reason to have two versions of each layer in the cache when really we only want to have it apply to the runtime environment. Passing the value as a build arg instead allows it to interact more carefully with the cache. Layers before the arg is mentioned in the Containerfile are blissfully unaware of it and because we really only want it for runtime, it can go right at the end and be used with an ENV instruction to introduce that environment variable for the only step that needs to be aware of it and rerun: setting the CMD.

Fixes: 8bfc3ca ("orbit: specify production config boolean via appropriate container-compose")