### PR TITLE
extenginx: Fix redirect to https port

### DIFF
--- a/extenginx/nginx.conf.template
+++ b/extenginx/nginx.conf.template
@@ -107,8 +107,9 @@ http {
 
 		include /etc/nginx/include.d/server_http/*.conf;
 
-
-		return 301 https://$host:${NGINX_HTTPS_PORT}$request_uri;
+		location / {
+			return 301 https://$host:${NGINX_HTTPS_PORT}$request_uri;
+		}
 	}
 }
 


### PR DESCRIPTION
putting the `return` directive at the top level means that all processing immediately stops (including location directives), so as written, it was impossible to actually add snippets to the http server that do anything.

Moving the return statment into a `location /` block will allow it to continue to function as a fallback, but allows more specific overrides to be provided with additional location blocks in included snippets.