### PR TITLE
Containerfiles: cleanup \ multi-line continuations to normalize last entry

### DIFF
--- a/extenginx/Containerfile
+++ b/extenginx/Containerfile
@@ -3,7 +3,8 @@ ARG NGINX_RUNTIME_SNIPPETS=0
 FROM alpine:3.19 AS build
 
 RUN apk update && apk upgrade && apk add \
-    envsubst
+    envsubst \
+    ;
 
 COPY nginx.conf.template .
 
@@ -19,7 +20,8 @@ FROM alpine:3.19 AS nginx-runtime-0
 
 RUN apk update && apk upgrade && apk add \
     nginx          \
-    nginx-mod-mail
+    nginx-mod-mail \
+    ;
 
 
 RUN mkdir -p \
@@ -30,7 +32,8 @@ RUN mkdir -p \
     /etc/nginx/include.d/server_http \
     /etc/nginx/include.d/mail \
     /etc/nginx/include.d/server_smtps \
-    /etc/nginx/include.d/server_pop3s
+    /etc/nginx/include.d/server_pop3s \
+    ;
 
 COPY --from=NGINX_SNIPPET_SOURCE . /etc/nginx/include.d/
 

--- a/orbit/Containerfile
+++ b/orbit/Containerfile
@@ -5,12 +5,14 @@ RUN apk update && apk upgrade && apk add \
 	py3-pip \
 	sqlite \
 	build-base \
-	libffi-dev
+	libffi-dev \
+	;
 
 COPY requirements.txt /requirements.txt
 RUN python3 -m venv /radius-venv && \
 	source /radius-venv/bin/activate && \
-	pip install -r requirements.txt
+	pip install -r requirements.txt && \
+	:
 
 COPY . /orbit
 WORKDIR /orbit
@@ -21,7 +23,8 @@ FROM alpine:3.19 AS orbit
 
 RUN apk update && apk upgrade && apk add \
 	python3 \
-	cgit
+	cgit \
+	;
 
 COPY --from=build /orbit /orbit
 COPY --from=build /radius-venv /radius-venv


### PR DESCRIPTION
Places where we use `\` to spread a command or string of commands across multiple lines should have a trailing line that does nothing so that all the real lines can look the same (i.e. all with \ or && \) so that future commit diffs can be tidy.

If you ever have to add something to the end of one of these improperly terminated lists, you will need to edit the previous last entry line and ruin its git blame with useless noise.

By creating this commit, I am creating such useless noise, but by doing it in a refactor commit that has no effect on behavior, I hope to help whoever comes across this while blaming to know they can skip it. This is not the commit you are looking for :)

Single commands whose arguments are spread can just have `;` on the last line, and pipelines separated by `&&` can be terminated by the `:` command which is a no-op.