### PR TITLE
Lfx cleanup

### DIFF
--- a/orbit/db.py
+++ b/orbit/db.py
@@ -115,14 +115,14 @@ def usr_setpwdhash_username(usr): return _set(USR_SETPWDHASH_USERNAME, usr)
 
 
 USR_GET = """
-SELECT id, username, pwdhash, lfx, student_id
+SELECT id, username, pwdhash, student_id
 FROM users;
 """.strip()
 def usr_get(): return _get(USR_GET)
 
 
 USR_GETBY_USERNAME = """
-SELECT id, username, pwdhash, lfx, student_id
+SELECT id, username, pwdhash, student_id
 FROM users
 WHERE username = ?;
 """.strip()

--- a/orbit/db.py
+++ b/orbit/db.py
@@ -92,8 +92,8 @@ def usr_pwdhashfor_username(usn): return _get(USR_PWDHASHFOR_USERNAME, usn)
 
 
 USR_INS = """
-INSERT INTO users (username, pwdhash, lfx, student_id)
-VALUES (?, ?, ?, ?);
+INSERT INTO users (username, pwdhash, student_id)
+VALUES (?, ?, ?);
 """.strip()
 def usr_ins(usr): return _set(USR_INS, usr)
 

--- a/orbit/db.py
+++ b/orbit/db.py
@@ -129,22 +129,6 @@ WHERE username = ?;
 def usr_getby_username(usn): return _get(USR_GETBY_USERNAME, usn)
 
 
-USR_SET_LFX = """
-UPDATE users
-SET lfx = True
-WHERE username = ?;
-""".strip()
-def usr_set_lfx(usn): return _set(USR_SET_LFX, usn)
-
-
-USR_SET_NOLFX = """
-UPDATE users
-SET lfx = False
-WHERE username = ?;
-""".strip()
-def usr_set_nolfx(usn): return _set(USR_SET_NOLFX, usn)
-
-
 # registration table inferface
 
 REG_INS = """

--- a/orbit/db.py
+++ b/orbit/db.py
@@ -145,14 +145,6 @@ WHERE username = ?;
 def usr_set_nolfx(usn): return _set(USR_SET_NOLFX, usn)
 
 
-USR_GETIF_LFX_USERNAME = """
-SELECT lfx
-FROM users
-WHERE username = ?;
-""".strip()
-def usr_getif_lfx_username(usn): return _get(USR_GETIF_LFX_USERNAME, usn)
-
-
 # registration table inferface
 
 REG_INS = """

--- a/orbit/hyperspace.py
+++ b/orbit/hyperspace.py
@@ -46,26 +46,6 @@ def do_query_username(args):
     print(USR_FMT.format(*u))
 
 
-def do_set_lfx(args):
-    need(args, u=True)
-
-    if db.usr_getby_username(args.username)[0]:
-        db.usr_set_lfx(args.username)
-    else:
-        nou(args.username)
-    do_query_username(args)
-
-
-def do_set_nolfx(args):
-    need(args, u=True)
-
-    if db.usr_getby_username(args.username)[0]:
-        db.usr_set_nolfx(args.username)
-    else:
-        nou(args.username)
-    do_query_username(args)
-
-
 def do_validate_token(args):
     need(args, t=True)
 

--- a/orbit/hyperspace.py
+++ b/orbit/hyperspace.py
@@ -33,7 +33,6 @@ USR_FMT = """
 Orbit ID        : {}
 Username        : {}
 Hashed Password : {}
-LFX enabled     : {}
 Student ID      : {}
 """.strip()
 

--- a/orbit/hyperspace.py
+++ b/orbit/hyperspace.py
@@ -209,12 +209,6 @@ def hyperspace_main(raw_args):
     actions.add_argument('-l', '--listsessions', action='store_const',
                          help='List of all known sessions (some could be invalid)',  # NOQA: E501
                          dest='do', const=do_list_sessions)
-    actions.add_argument('-x', '--lfxenable', action='store_const',
-                         help='Set supplied username lfx status to true',
-                         dest='do', const=do_set_lfx)
-    actions.add_argument('-y', '--lfxdisable', action='store_const',
-                         help='Set supplied username lfx status to false',
-                         dest='do', const=do_set_nolfx)
     actions.add_argument('-q', '--queryuser', action='store_const',
                          help='Get information about supplied username if valid',  # NOQA: E501
                          dest='do', const=do_query_username)

--- a/orbit/hyperspace.py
+++ b/orbit/hyperspace.py
@@ -140,7 +140,7 @@ def do_newuser(args):
         errx(f'cannot create duplicate user "{args.username}"')
     else:
         db.usr_ins((args.username, do_bcrypt_hash(args, get=True),
-                    0, args.studentid or 0))
+                    args.studentid or 0))
     if args.studentid:
         db.reg_ins((args.username, args.password, args.studentid))
     do_validate_creds(args)

--- a/orbit/init-db.sql
+++ b/orbit/init-db.sql
@@ -4,7 +4,6 @@ CREATE TABLE users (
 	id integer primary key,
 	username string UNIQUE NOT NULL,
 	pwdhash string NOT NULL,
-	lfx boolean NOT NULL DEFAULT FALSE,
 	student_id integer);
 CREATE TABLE sessions (
         token string PRIMARY KEY,

--- a/orbit/init-db.sql
+++ b/orbit/init-db.sql
@@ -4,7 +4,7 @@ CREATE TABLE users (
 	id integer primary key,
 	username string UNIQUE NOT NULL,
 	pwdhash string NOT NULL,
-	lfx boolean NOT NULL,
+	lfx boolean NOT NULL DEFAULT FALSE,
 	student_id integer);
 CREATE TABLE sessions (
         token string PRIMARY KEY,


### PR DESCRIPTION
Since we have found a solution for running more than one independent version of the infrastructure, we no longer need to support lfx/non lfx for the mail servers. Since 326c3d6 we have not done so, but the lfx field remains in the database and in several queries. This PR removes all references to it.