### PR TITLE
Remove unused db queries

### DIFF
--- a/orbit/db.py
+++ b/orbit/db.py
@@ -154,48 +154,6 @@ WHERE username = ?;
 def usr_getif_lfx_username(usn): return _get(USR_GETIF_LFX_USERNAME, usn)
 
 
-# submission table interface
-
-SUB_GETFOR_USERNAME_ASN = """
-SELECT (submission_id, student_id, assignment_id,
-    submission_name, submission_grade, submission_comments)
-FROM submissions
-WHERE student_id = ?
-AND assignment_id = ?;
-""".strip()
-def sub_getfor_username_asn(dub): return _get(SUB_GETFOR_USERNAME_ASN, dub)
-
-
-SUB_GET = """
-SELECT *
-FROM submissions;
-""".strip()
-def sub_get(): return _get(SUB_GET)
-
-
-SUB_INS = """
-INSERT INTO submissions (sub_id, username, timestamp, _from, _to, email_ids, subjects)
-VALUES (?,?,?,?,?,?,?);
-""".strip()  # NOQA: E501
-def sub_ins(sub): return _set(SUB_INS, sub)
-
-
-SUB_GETBY_SUBID = """
-SELECT sub_id, username, timestamp, _from, _to, email_ids, subjects
-FROM submissions
-WHERE sub_id = ?;
-""".strip()
-def sub_getby_subid(sid): return _get(SUB_GETBY_SUBID, sid)
-
-
-SUB_GETBY_USERNAME = """
-SELECT sub_id, username, timestamp, _from, _to, email_ids, subjects
-FROM submissions
-WHERE user = ?;
-""".strip()
-def sub_getby_username(usr): return _get(SUB_GETBY_USERNAME, usr)
-
-
 # assignment table interface
 
 ASN_GETBY_WID = """

--- a/orbit/db.py
+++ b/orbit/db.py
@@ -153,31 +153,6 @@ WHERE username = ?;
 def usr_getif_lfx_username(usn): return _get(USR_GETIF_LFX_USERNAME, usn)
 
 
-# assignment table interface
-
-ASN_GETBY_WID = """
-SELECT web_id, email_id
-FROM assignments
-WHERE web_id = ?;
-""".strip()
-def asn_getby_webid(wid): return _get(ASN_GETBY_WID, wid)
-
-
-ASN_GETBY_EID = """
-SELECT web_id, email_id
-FROM assignments
-WHERE email_id = ?;
-""".strip()
-def asn_getby_email_id(eid): return _get(ASN_GETBY_EID, eid)
-
-
-ASN_GET = """
-SELECT *
-FROM assignments;
-""".strip()
-def asn_get(): return _get(ASN_GET)
-
-
 # registration table inferface
 
 REG_INS = """

--- a/orbit/db.py
+++ b/orbit/db.py
@@ -2,6 +2,7 @@ import sqlite3
 import config
 # nickname  table name
 # USR => users
+# SES => sessions
 # REG => newusers
 import sys
 

--- a/orbit/db.py
+++ b/orbit/db.py
@@ -43,14 +43,6 @@ WHERE token = ?;
 def ses_getby_token(tok): return _get(SES_GETBY_TOKEN, tok)
 
 
-SES_SETEXPIRY_TOKEN = """
-UPDATE sessions
-SET expiry = ?
-WHERE token = ?;
-""".strip()
-def ses_setexpiry_token(tex): return _set(SES_SETEXPIRY_TOKEN, tex)
-
-
 SES_GETBY_USERNAME = """
 SELECT token, username, expiry
 FROM sessions

--- a/orbit/db.py
+++ b/orbit/db.py
@@ -2,7 +2,6 @@ import sqlite3
 import config
 # nickname  table name
 # USR => users
-# ASN => assignments
 # REG => newusers
 import sys
 

--- a/orbit/db.py
+++ b/orbit/db.py
@@ -3,7 +3,6 @@ import config
 # nickname  table name
 # USR => users
 # ASN => assignments
-# SUB => submissions
 # REG => newusers
 import sys
 

--- a/orbit/hyperspace.py
+++ b/orbit/hyperspace.py
@@ -238,13 +238,6 @@ def hyperspace_main(raw_args):
     actions.add_argument('-q', '--queryuser', action='store_const',
                          help='Get information about supplied username if valid',  # NOQA: E501
                          dest='do', const=do_query_username)
-    actions.add_argument('-a', '--assignments', action='store_const',
-                         help='Get the full assignment list',
-                         dest='do', const=do_list_asn)
-
-    actions.add_argument('-z', '--plaininboxes', action='store_const',
-                         help='Get plain list of local submission inboxes',
-                         dest='do', const=do_list_inbox)
 
     args = parser.parse_args(raw_args)
     if (args.do):

--- a/orbit/hyperspace.py
+++ b/orbit/hyperspace.py
@@ -166,26 +166,6 @@ def do_list_sessions(args):
                                         session[0]) for session in raw_list]))
 
 
-ASN_FMT = """
-{} submitted to mailbox {}
-""".strip()
-
-
-def do_list_asn(args):
-    raw_list = db.asn_get()
-    print('\n'.join([ASN_FMT.format(asn[0], asn[1]) for asn in raw_list]))
-
-
-INBOX_FMT = """
-{} submitted to {}@{}
-""".strip()
-
-
-def do_list_inbox(args):
-    raw_list = db.asn_get()
-    print('\n'.join([asn[1] for asn in raw_list]))
-
-
 def hyperspace_main(raw_args):
     parser = argparse.ArgumentParser(prog='hyperspace',
                                      description='Administrate Orbit',

--- a/orbit/init-db.sql
+++ b/orbit/init-db.sql
@@ -10,21 +10,9 @@ CREATE TABLE sessions (
         token string PRIMARY KEY,
         username string UNIQUE NOT NULL,
         expiry string NOT NULL);
-CREATE TABLE assignments (
-	web_id string PRIMARY KEY,
-	email_id string NOT NULL);
 CREATE TABLE newusers (
 	registration_id integer primary key,
 	student_id string UNIQUE NOT NULL,
 	username string UNIQUE NOT NULL,
 	password string NOT NULL);
-INSERT INTO assignments (web_id, email_id) VALUES ('setup', 'introductions');
-INSERT INTO assignments (web_id, email_id) VALUES ('E0', 'exercise0');
-INSERT INTO assignments (web_id, email_id) VALUES ('E1', 'exercise1');
-INSERT INTO assignments (web_id, email_id) VALUES ('E2', 'exercise2');
-INSERT INTO assignments (web_id, email_id) VALUES ('P0', 'programming0');
-INSERT INTO assignments (web_id, email_id) VALUES ('P1', 'programming1');
-INSERT INTO assignments (web_id, email_id) VALUES ('P2', 'programming2');
-INSERT INTO assignments (web_id, email_id) VALUES ('F0', 'final0');
-INSERT INTO assignments (web_id, email_id) VALUES ('F1', 'final1');
 COMMIT;

--- a/orbit/init-db.sql
+++ b/orbit/init-db.sql
@@ -10,14 +10,6 @@ CREATE TABLE sessions (
         token string PRIMARY KEY,
         username string UNIQUE NOT NULL,
         expiry string NOT NULL);
-CREATE TABLE submissions (
-	sub_id string PRIMARY KEY,
-	username string NOT NULL,
-	time string NOT NULL,
-	_to string NOT NULL,
-	_from string NOT NULL,
-	email_ids string NOT NULL,
-	subjects string NOT NULL);
 CREATE TABLE assignments (
 	web_id string PRIMARY KEY,
 	email_id string NOT NULL);


### PR DESCRIPTION
Lots of stuff in db.py is totally unused. Get rid of it to make switching to an ORM more painless.