### PR TITLE
orbit: warpdrive: use sane defaults for env vars

### DIFF
--- a/orbit/warpdrive.sh
+++ b/orbit/warpdrive.sh
@@ -4,8 +4,8 @@
 
 cd "$(dirname "$0")"
 
-DOCKER=${DOCKER:-sudo docker}
-CONTAINER=${CONTAINER:-docker_orbit_1}
+DOCKER=${DOCKER:-podman}
+CONTAINER=${CONTAINER:-singularity_orbit_1}
 
 cat <<EOF | $DOCKER exec -i $CONTAINER /bin/sh
 . /radius-venv/bin/activate


### PR DESCRIPTION
set CONTAINER to singularity_orbit_1 which is essentially invariant and set DOCKER to our more commonly used podman. The script works with the default environment and sudoless invocation when the dev instance is the target, and works on the production/staging when sudoed.

Perhaps we should remove the CONTAINER env var entirely as I can't see how it would reasonably vary.