### PR TITLE
tcp_server: specify handler for SIGTERM so it is not ignored

### DIFF
--- a/tcp_server/tcp_server.c
+++ b/tcp_server/tcp_server.c
@@ -95,6 +95,8 @@ static void setup_signal_handler(void)
 	child_act.sa_flags |= SA_NOCLDWAIT; //avoid needing to reap children processes
 	if(0 > sigaction(SIGCHLD, &child_act, NULL))
 		err(1, "failed to set signal action for SIGCHLD (this is a bug)");
+	if(SIG_ERR == signal(SIGTERM, _Exit))
+		err(1, "failed to set handler for SIGTERM (this is a bug)");
 }
 
 static void setup_chroot(const char *chroot_path)


### PR DESCRIPTION
Only signals that pid 1 has explicitly defined handlers for can be sent to pid 1 (including the first process in a container). For smtp and pop this is an instance of tcp_server. Since tcp_server does not define a handler for SIGTERM, the signal is ignored when tcp_server is acting as the init process of the container. Fixes #50