### PR TITLE
Remove host port mappings for backend containers and isolate them with networks

### DIFF
--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -60,6 +60,10 @@ services:
       - orbit
       - smtp
       - pop
+    networks:
+      - orbit
+      - smtp
+      - pop
   orbit:
     build:
       context: orbit
@@ -80,6 +84,8 @@ services:
         target: /orbit/docs
         read_only: true
         selinux: z
+    networks:
+      - orbit
   smtp:
     build:
       context: smtp
@@ -96,6 +102,8 @@ services:
         target: /mnt/email_data
         read_only: false
         selinux: z
+    networks:
+      - smtp
   pop:
     build:
       context: pop
@@ -111,3 +119,9 @@ services:
         target: /mnt/mail
         read_only: true
         selinux: z
+    networks:
+      - pop
+networks:
+  orbit:
+  smtp:
+  pop:

--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -118,10 +118,3 @@ services:
         target: /mnt/mail
         read_only: true
         selinux: z
-    ports:
-      - target: 1995
-        published: 11995
-        protocol: tcp
-        app_protocol: pop3
-        mode: host
-        name: "unencrypted pop3 upstream server port"

--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -96,13 +96,6 @@ services:
         target: /mnt/email_data
         read_only: false
         selinux: z
-    ports:
-      - target: 1465
-        published: 11465
-        protocol: tcp
-        app_protocol: smtp
-        mode: host
-        name: "unencrypted smtp upstream server port"
   pop:
     build:
       context: pop

--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -80,13 +80,6 @@ services:
         target: /orbit/docs
         read_only: true
         selinux: z
-    ports:
-      - target: 9098
-        published: 9098
-        protocol: tcp
-        app_protocol: http
-        mode: host
-        name: "unencrypted http upstream server port"
   smtp:
     build:
       context: smtp

--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -56,6 +56,10 @@ services:
         app_protocol: pop3s
         mode: host
         name: "port for pop3s connections to proxy"
+    depends_on:
+      - orbit
+      - smtp
+      - pop
   orbit:
     build:
       context: orbit

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -108,10 +108,3 @@ services:
         target: /mnt/mail
         read_only: true
         selinux: z
-    ports:
-      - target: 1995
-        published: 11995
-        protocol: tcp
-        app_protocol: pop3
-        mode: host
-        name: "unencrypted pop3 upstream server port"

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -86,13 +86,6 @@ services:
         target: /mnt/email_data
         read_only: false
         selinux: z
-    ports:
-      - target: 1465
-        published: 11465
-        protocol: tcp
-        app_protocol: smtp
-        mode: host
-        name: "unencrypted smtp upstream server port"
   pop:
     build:
       context: pop

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -52,6 +52,10 @@ services:
       - orbit
       - smtp
       - pop
+    networks:
+      - orbit
+      - smtp
+      - pop
   orbit:
     build:
       context: orbit
@@ -70,6 +74,8 @@ services:
         target: /orbit/docs
         read_only: true
         selinux: z
+    networks:
+      - orbit
   smtp:
     build:
       context: smtp
@@ -86,6 +92,8 @@ services:
         target: /mnt/email_data
         read_only: false
         selinux: z
+    networks:
+      - smtp
   pop:
     build:
       context: pop
@@ -101,3 +109,9 @@ services:
         target: /mnt/mail
         read_only: true
         selinux: z
+    networks:
+      - pop
+networks:
+  orbit:
+  smtp:
+  pop:

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -48,6 +48,10 @@ services:
         app_protocol: pop3s
         mode: host
         name: "port for pop3s connections to proxy"
+    depends_on:
+      - orbit
+      - smtp
+      - pop
   orbit:
     build:
       context: orbit

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -70,13 +70,6 @@ services:
         target: /orbit/docs
         read_only: true
         selinux: z
-    ports:
-      - target: 9098
-        published: 9098
-        protocol: tcp
-        app_protocol: http
-        mode: host
-        name: "unencrypted http upstream server port"
   smtp:
     build:
       context: smtp

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -108,10 +108,3 @@ services:
         target: /mnt/mail
         read_only: true
         selinux: z
-    ports:
-      - target: 1995
-        published: 11995
-        protocol: tcp
-        app_protocol: pop3
-        mode: host
-        name: "unencrypted pop3 upstream server port"

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -86,13 +86,6 @@ services:
         target: /mnt/email_data
         read_only: false
         selinux: z
-    ports:
-      - target: 1465
-        published: 11465
-        protocol: tcp
-        app_protocol: smtp
-        mode: host
-        name: "unencrypted smtp upstream server port"
   pop:
     build:
       context: pop

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -52,6 +52,10 @@ services:
       - orbit
       - smtp
       - pop
+    networks:
+      - orbit
+      - smtp
+      - pop
   orbit:
     build:
       context: orbit
@@ -70,6 +74,8 @@ services:
         target: /orbit/docs
         read_only: true
         selinux: z
+    networks:
+      - orbit
   smtp:
     build:
       context: smtp
@@ -86,6 +92,8 @@ services:
         target: /mnt/email_data
         read_only: false
         selinux: z
+    networks:
+      - smtp
   pop:
     build:
       context: pop
@@ -101,3 +109,9 @@ services:
         target: /mnt/mail
         read_only: true
         selinux: z
+    networks:
+      - pop
+networks:
+  orbit:
+  smtp:
+  pop:

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -48,6 +48,10 @@ services:
         app_protocol: pop3s
         mode: host
         name: "port for pop3s connections to proxy"
+    depends_on:
+      - orbit
+      - smtp
+      - pop
   orbit:
     build:
       context: orbit

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -70,13 +70,6 @@ services:
         target: /orbit/docs
         read_only: true
         selinux: z
-    ports:
-      - target: 9098
-        published: 9098
-        protocol: tcp
-        app_protocol: http
-        mode: host
-        name: "unencrypted http upstream server port"
   smtp:
     build:
       context: smtp

--- a/nginx_snippets/http/00-mail_auth.conf
+++ b/nginx_snippets/http/00-mail_auth.conf
@@ -3,7 +3,7 @@ server {
 	listen 127.0.0.1:13337 default_server;
 	location /mail_auth {
 		include uwsgi_params;
-		proxy_pass http://host.containers.internal:9098;
+		proxy_pass http://orbit:9098;
 	}
 
 	location = /mail_auth/pop {

--- a/nginx_snippets/server_https/01-orbit-paths.conf
+++ b/nginx_snippets/server_https/01-orbit-paths.conf
@@ -8,5 +8,5 @@ location @login {
 location ~* ^((.*\.md)|/log(in|out)|/dashboard|/register|/cgit.*)$ {
 	include uwsgi_params;
 	proxy_intercept_errors on;
-	proxy_pass http://host.containers.internal:9098;
+	proxy_pass http://orbit:9098;
 }

--- a/nginx_snippets/stream/00-pop-proxy.conf
+++ b/nginx_snippets/stream/00-pop-proxy.conf
@@ -1,4 +1,4 @@
 server {
 	listen 127.0.0.1:2995;
-	proxy_pass host.containers.internal:11995;
+	proxy_pass pop:1995;
 }

--- a/nginx_snippets/stream/01-smtp-proxy.conf
+++ b/nginx_snippets/stream/01-smtp-proxy.conf
@@ -1,4 +1,4 @@
 server {
 	listen 127.0.0.1:2465;
-	proxy_pass host.containers.internal:11465;
+	proxy_pass smtp:1465;
 }


### PR DESCRIPTION
The backend containers do not need to have exposed ports on the host when nginx can instead just connect directly to them. The prior state of the art was necessitated primarily by the kludge for mail auth where having one hostname to resolve (the host instead of pop/smtp containers) made things more palatable.

The backend containers also do not need to be able to communicate with each other, only with nginx. Using networks can allows for this sort of isolation.