### PR TITLE
rename additional contexts to use all lowercase

### DIFF
--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: extenginx
       additional_contexts:
-        - NGINX_SNIPPET_SOURCE=./nginx_snippets
+        - nginx_snippet_source=./nginx_snippets
       dockerfile: Containerfile
       target: nginx
       args:

--- a/container-compose-dev.yml
+++ b/container-compose-dev.yml
@@ -91,7 +91,7 @@ services:
       context: smtp
       dockerfile: Containerfile
       additional_contexts:
-        - TCP_SERVER_SOURCE=./tcp_server
+        - tcp_server_source=./tcp_server
       target: smtp
       args:
         hostname: localhost
@@ -109,7 +109,7 @@ services:
       context: pop
       dockerfile: Containerfile
       additional_contexts:
-        - TCP_SERVER_SOURCE=./tcp_server
+        - tcp_server_source=./tcp_server
       target: pop
       args:
         LISTEN_PORT: 1995

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -81,7 +81,7 @@ services:
       context: smtp
       dockerfile: Containerfile
       additional_contexts:
-        - TCP_SERVER_SOURCE=./tcp_server
+        - tcp_server_source=./tcp_server
       target: smtp
       args:
         hostname: dev.underground.software
@@ -99,7 +99,7 @@ services:
       context: pop
       dockerfile: Containerfile
       additional_contexts:
-        - TCP_SERVER_SOURCE=./tcp_server
+        - tcp_server_source=./tcp_server
       target: pop
       args:
         LISTEN_PORT: 1995

--- a/container-compose-staging.yml
+++ b/container-compose-staging.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: extenginx
       additional_contexts:
-        - NGINX_SNIPPET_SOURCE=./nginx_snippets
+        - nginx_snippet_source=./nginx_snippets
       dockerfile: Containerfile
       target: nginx
       args:

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -3,7 +3,7 @@ services:
     build:
       context: extenginx
       additional_contexts:
-        - NGINX_SNIPPET_SOURCE=./nginx_snippets
+        - nginx_snippet_source=./nginx_snippets
       dockerfile: Containerfile
       target: nginx
       args:

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -81,7 +81,7 @@ services:
       context: smtp
       dockerfile: Containerfile
       additional_contexts:
-        - TCP_SERVER_SOURCE=./tcp_server
+        - tcp_server_source=./tcp_server
       target: smtp
       args:
         hostname: kdlp.underground.software
@@ -99,7 +99,7 @@ services:
       context: pop
       dockerfile: Containerfile
       additional_contexts:
-        - TCP_SERVER_SOURCE=./tcp_server
+        - tcp_server_source=./tcp_server
       target: pop
       args:
         LISTEN_PORT: 1995

--- a/extenginx/Containerfile
+++ b/extenginx/Containerfile
@@ -36,7 +36,7 @@ RUN mkdir -p \
     /etc/nginx/include.d/server_pop3s \
     ;
 
-COPY --from=NGINX_SNIPPET_SOURCE . /etc/nginx/include.d/
+COPY --from=nginx_snippet_source . /etc/nginx/include.d/
 
 COPY --from=build nginx.conf /etc/nginx/
 

--- a/pop/Containerfile
+++ b/pop/Containerfile
@@ -4,7 +4,7 @@ RUN apk add \
 	make \
 	;
 
-COPY --from=TCP_SERVER_SOURCE . /tcp_server
+COPY --from=tcp_server_source . /tcp_server
 ARG LISTEN_PORT=995
 RUN make -C /tcp_server CC='clang -static' DEFAULT_PORT=${LISTEN_PORT}
 

--- a/smtp/Containerfile
+++ b/smtp/Containerfile
@@ -4,7 +4,7 @@ RUN apk add \
 	make \
 	;
 
-COPY --from=TCP_SERVER_SOURCE . /tcp_server
+COPY --from=tcp_server_source . /tcp_server
 ARG LISTEN_PORT=465
 RUN make -C /tcp_server CC='clang -static' DEFAULT_PORT=${LISTEN_PORT}
 


### PR DESCRIPTION
docker doesn't like additional contexts that contain capital letters so if we want compatibility we need to make this minor refactor.