### PR TITLE
container compose: fix selinux for bind mount

### DIFF
--- a/container-compose.yml
+++ b/container-compose.yml
@@ -17,7 +17,8 @@ services:
         source: ./socks
         target: /run/nginx/socks
         read_only: false
-        selinux: z
+        bind:
+          selinux: z
       - type: volume
         source: ssl-certs
         target: /etc/ssl/nginx


### PR DESCRIPTION
turns out I was using the wrong syntax for setting selinux on a bind mount verbosely. There is a corresponding fixup commit pushed to kdlp-devel in the podman compose fork.