### PR TITLE
Smtp cleanup

### DIFF
--- a/smtp/Containerfile
+++ b/smtp/Containerfile
@@ -30,4 +30,4 @@ USER 100:100
 
 ARG LISTEN_PORT=465
 EXPOSE ${LISTEN_PORT}
-ENTRYPOINT ["/usr/local/bin/tcp_server", "/usr/local/bin/smtp", "smtp", "/mnt/email_data"]
+ENTRYPOINT ["/usr/local/bin/tcp_server", "/usr/local/bin/smtp", "smtp", "/mnt/email_data/mail", "/mnt/email_data/logs"]

--- a/smtp/smtp.c
+++ b/smtp/smtp.c
@@ -594,18 +594,6 @@ static void handle_rcpt(enum state *state)
 			dprintf(CURR_EMAIL_FD, "To: <%.*s@" HOSTNAME ">\r\n", (int)recipient_size, recipient);
 			dprintf(CURR_SESSION_FD, "%.*s ", (int)recipient_size, recipient);
 			*state = RCPT;
-			int assignment_log_fd = openat(base_dir_fd, recipient,
-				O_CLOEXEC | O_DIRECTORY | O_PATH);
-			if(0 > assignment_log_fd)
-				REPLY("250 OK")
-			if(0 > fstat(assignment_log_fd, &statbuf))
-				warn("Unable to stat assignment_log_fd");
-			if(base_dev != statbuf.st_dev)
-				warnx("Logs directory should be stored on the same physical device as the base dir");
-			if(0 > dup3(assignment_log_fd, CURR_SESSION_DIR_FD, O_CLOEXEC))
-				warn("Unable to dup assignment_log_fd into CURR_SESSION_DIR_FD");
-			if(0 > fchown(CURR_EMAIL_FD, statbuf.st_uid, statbuf.st_gid))
-				warn("Unable to chown email to assignment group");
 			REPLY("250 OK")
 		}
 		dprintf(CURR_EMAIL_FD, " , <%.*s@" HOSTNAME ">\r\n", (int)recipient_size, recipient);

--- a/smtp/smtp.c
+++ b/smtp/smtp.c
@@ -592,6 +592,7 @@ static void handle_rcpt(enum state *state)
 		if(*state < RCPT) //first recipient (only ever one iteration)
 		{
 			dprintf(CURR_EMAIL_FD, "To: <%.*s@" HOSTNAME ">\r\n", (int)recipient_size, recipient);
+			dprintf(CURR_SESSION_FD, "%.*s ", (int)recipient_size, recipient);
 			*state = RCPT;
 			int assignment_log_fd = openat(base_dir_fd, recipient,
 				O_CLOEXEC | O_DIRECTORY | O_PATH);

--- a/smtp/smtp.c
+++ b/smtp/smtp.c
@@ -770,11 +770,11 @@ int main(int argc, char **argv)
 
 	mail_dir_fd = openat(AT_FDCWD, argv[1], O_CLOEXEC | O_DIRECTORY | O_PATH);
 	if(0 > mail_dir_fd)
-		err(1, "Unable to open mail directory");
+		err(1, "Unable to open mail directory: %s", argv[1]);
 
 	log_dir_fd = openat(AT_FDCWD, argv[2], O_CLOEXEC | O_DIRECTORY | O_PATH);
 	if(0 > log_dir_fd)
-		err(1, "Unable to open logs directory");
+		err(1, "Unable to open logs directory: %s", argv[2]);
 
 	SEND("220 SMTP server ready");
 	for(enum state state = START; state != QUIT;)


### PR DESCRIPTION
using multiple folders for submissions logs was really an artifact of the unix permissions approach to mail access control. Since we are moving away from that, we can remove this complexity and make the SMTP server more straightfoward.