### PR TITLE
Improve Smtp Id Strings

### DIFF
--- a/smtp/smtp.c
+++ b/smtp/smtp.c
@@ -373,8 +373,8 @@ static void unique_string(size_t size, char *buf)
 	static uint64_t sequence_counter = 0;
 	uint64_t sequence_num = sequence_counter++;
 	uint64_t timestamp = (uint64_t)time(NULL);
-	uint64_t pid = (uint64_t)getpid();
-	int ret = snprintf(buf, size, "%" PRIu64 ".%" PRIu64 ".%" PRIu64,
+	uint32_t pid = (uint32_t)getpid();
+	int ret = snprintf(buf, size, "%" PRIu32 ".%" PRIu64 ".%" PRIu64,
 		pid, timestamp, sequence_num);
 	if(ret < 0)
 		bail("snprintf failed mysteriously");

--- a/smtp/smtp.c
+++ b/smtp/smtp.c
@@ -376,6 +376,8 @@ static void unique_string(size_t size, char *buf)
 	uint32_t sequence_num = sequence_counter++;
 	uint64_t timestamp = (uint64_t)time(NULL);
 	uint32_t pid = (uint32_t)getpid();
+	if(!sequence_counter)
+		bail("sequence counter wrapped around. Too many ids used");
 	int ret = snprintf(buf, size, "%016" SCNx64 "%08" SCNx32 "%08" SCNx32,
 		timestamp, pid, sequence_num);
 	if(ret < 0)

--- a/smtp/smtp.c
+++ b/smtp/smtp.c
@@ -403,7 +403,6 @@ static size_t from_address_size;
 static char username[256];
 static size_t username_size;
 static char message_id[256];
-static size_t message_id_size;
 static char recipient[256];
 static size_t recipient_size;
 
@@ -516,9 +515,8 @@ static void handle_mail(enum state *state)
 	switch(*state)
 	{
 	case LOGIN:
-		message_id_size = unique_string(sizeof message_id, message_id);
 		//this should be impossible
-		if(-(size_t)1 == message_id_size)
+		if(-(size_t)1 == unique_string(sizeof message_id, message_id))
 			bail("not enough space for message_id");
 		from_address_size = (size_t)snprintf(from_address, sizeof from_address,
 			" from:<%.*s@" HOSTNAME ">", (int)username_size, username);
@@ -542,8 +540,8 @@ static void handle_mail(enum state *state)
 		}
 		dprintf(CURR_EMAIL_FD,
 			"Received: by " HOSTNAME " ; %s\r\n"
-			"Message-ID: <%.*s@" HOSTNAME ">\r\nFrom: <%.*s@" HOSTNAME ">\r\n",
-			now(), (int)message_id_size, message_id, (int)username_size, username);
+			"Message-ID: <%s@" HOSTNAME ">\r\nFrom: <%.*s@" HOSTNAME ">\r\n",
+			now(), message_id, (int)username_size, username);
 		*state = MAIL;
 		REPLY("250 OK")
 	case GREET:

--- a/smtp/smtp.c
+++ b/smtp/smtp.c
@@ -376,7 +376,7 @@ static void unique_string(size_t size, char *buf)
 	uint32_t sequence_num = sequence_counter++;
 	uint64_t timestamp = (uint64_t)time(NULL);
 	uint32_t pid = (uint32_t)getpid();
-	int ret = snprintf(buf, size, "%" SCNu64 ".%" SCNu32 ".%" SCNu32,
+	int ret = snprintf(buf, size, "%016" SCNx64 "%08" SCNx32 "%08" SCNx32,
 		timestamp, pid, sequence_num);
 	if(ret < 0)
 		bail("snprintf failed mysteriously");

--- a/smtp/smtp.c
+++ b/smtp/smtp.c
@@ -372,11 +372,11 @@ static void unique_string(size_t size, char *buf)
 {
 	_Static_assert(sizeof(time_t) <= sizeof(uint64_t), "uint64_t is not big enough to hold time_t values");
 	_Static_assert(sizeof(pid_t) <= sizeof(uint32_t), "uint32_t is not big enough to hold pid_t values");
-	static uint64_t sequence_counter = 0;
-	uint64_t sequence_num = sequence_counter++;
+	static uint32_t sequence_counter = 0;
+	uint32_t sequence_num = sequence_counter++;
 	uint64_t timestamp = (uint64_t)time(NULL);
 	uint32_t pid = (uint32_t)getpid();
-	int ret = snprintf(buf, size, "%" PRIu32 ".%" PRIu64 ".%" PRIu64,
+	int ret = snprintf(buf, size, "%" PRIu32 ".%" PRIu64 ".%" PRIu32,
 		pid, timestamp, sequence_num);
 	if(ret < 0)
 		bail("snprintf failed mysteriously");

--- a/smtp/smtp.c
+++ b/smtp/smtp.c
@@ -376,7 +376,7 @@ static void unique_string(size_t size, char *buf)
 	uint32_t sequence_num = sequence_counter++;
 	uint64_t timestamp = (uint64_t)time(NULL);
 	uint32_t pid = (uint32_t)getpid();
-	int ret = snprintf(buf, size, "%" PRIu32 ".%" PRIu64 ".%" PRIu32,
+	int ret = snprintf(buf, size, "%" SCNu32 ".%" SCNu64 ".%" SCNu32,
 		pid, timestamp, sequence_num);
 	if(ret < 0)
 		bail("snprintf failed mysteriously");

--- a/smtp/smtp.c
+++ b/smtp/smtp.c
@@ -370,6 +370,8 @@ static bool validate_and_case_fold_email_address(size_t size, char *buff)
 
 static void unique_string(size_t size, char *buf)
 {
+	_Static_assert(sizeof(time_t) <= sizeof(uint64_t), "uint64_t is not big enough to hold time_t values");
+	_Static_assert(sizeof(pid_t) <= sizeof(uint32_t), "uint32_t is not big enough to hold pid_t values");
 	static uint64_t sequence_counter = 0;
 	uint64_t sequence_num = sequence_counter++;
 	uint64_t timestamp = (uint64_t)time(NULL);

--- a/smtp/smtp.c
+++ b/smtp/smtp.c
@@ -376,8 +376,8 @@ static void unique_string(size_t size, char *buf)
 	uint32_t sequence_num = sequence_counter++;
 	uint64_t timestamp = (uint64_t)time(NULL);
 	uint32_t pid = (uint32_t)getpid();
-	int ret = snprintf(buf, size, "%" SCNu32 ".%" SCNu64 ".%" SCNu32,
-		pid, timestamp, sequence_num);
+	int ret = snprintf(buf, size, "%" SCNu64 ".%" SCNu32 ".%" SCNu32,
+		timestamp, pid, sequence_num);
 	if(ret < 0)
 		bail("snprintf failed mysteriously");
 	if(size <= (size_t)ret)

--- a/smtp/smtp.c
+++ b/smtp/smtp.c
@@ -537,7 +537,6 @@ static void handle_mail(enum state *state)
 			}
 		}
 		message_id_size = unique_string(sizeof message_id, message_id);
-		message_id[message_id_size] = '\0';
 		dprintf(CURR_EMAIL_FD,
 			"Received: by " HOSTNAME " ; %s\r\n"
 			"Message-ID: <%.*s@" HOSTNAME ">\r\nFrom: <%.*s@" HOSTNAME ">\r\n",

--- a/smtp/smtp.c
+++ b/smtp/smtp.c
@@ -373,9 +373,16 @@ static void generate_smtp_id(size_t size, char *buf)
 	_Static_assert(sizeof(time_t) <= sizeof(uint64_t), "uint64_t is not big enough to hold time_t values");
 	_Static_assert(sizeof(pid_t) <= sizeof(uint32_t), "uint32_t is not big enough to hold pid_t values");
 	static uint32_t sequence_counter = 0;
+	static uint32_t pid = 0;
+	static uint64_t timestamp = 0;
+	//one time initialization of values that uniquely identify this process
+	if(!pid)
+	{
+		pid = (uint32_t)getpid();
+		timestamp = (uint64_t)time(NULL);
+	}
+
 	uint32_t sequence_num = sequence_counter++;
-	uint64_t timestamp = (uint64_t)time(NULL);
-	uint32_t pid = (uint32_t)getpid();
 	if(!sequence_counter)
 		bail("sequence counter wrapped around. Too many ids used");
 	int ret = snprintf(buf, size, "%016" SCNx64 "%08" SCNx32 "%08" SCNx32,

--- a/smtp/smtp.c
+++ b/smtp/smtp.c
@@ -516,6 +516,10 @@ static void handle_mail(enum state *state)
 	switch(*state)
 	{
 	case LOGIN:
+		message_id_size = unique_string(sizeof message_id, message_id);
+		//this should be impossible
+		if(-(size_t)1 == message_id_size)
+			bail("not enough space for message_id");
 		from_address_size = (size_t)snprintf(from_address, sizeof from_address,
 			" from:<%.*s@" HOSTNAME ">", (int)username_size, username);
 		//this should be impossible
@@ -536,7 +540,6 @@ static void handle_mail(enum state *state)
 					REPLY("451 Unable allocate descriptor to store message")
 			}
 		}
-		message_id_size = unique_string(sizeof message_id, message_id);
 		dprintf(CURR_EMAIL_FD,
 			"Received: by " HOSTNAME " ; %s\r\n"
 			"Message-ID: <%.*s@" HOSTNAME ">\r\nFrom: <%.*s@" HOSTNAME ">\r\n",

--- a/smtp/smtp.c
+++ b/smtp/smtp.c
@@ -368,7 +368,7 @@ static bool validate_and_case_fold_email_address(size_t size, char *buff)
 	return true;
 }
 
-static void unique_string(size_t size, char *buf)
+static void generate_smtp_id(size_t size, char *buf)
 {
 	_Static_assert(sizeof(time_t) <= sizeof(uint64_t), "uint64_t is not big enough to hold time_t values");
 	_Static_assert(sizeof(pid_t) <= sizeof(uint32_t), "uint32_t is not big enough to hold pid_t values");
@@ -416,7 +416,7 @@ static void close_log_session(void)
 	if(0 > fdatasync(CURR_SESSION_FD))
 		warn("Unable to sync session log to disk");
 	char filename[256];
-	unique_string(sizeof filename, filename);
+	generate_smtp_id(sizeof filename, filename);
 #ifdef LINKAT_NOT_BROKEN
 	if(0 > linkat(CURR_SESSION_FD, "", log_dir_fd, filename, AT_EMPTY_PATH))
 #else
@@ -519,7 +519,7 @@ static void handle_mail(enum state *state)
 	switch(*state)
 	{
 	case LOGIN:
-		unique_string(sizeof message_id, message_id);
+		generate_smtp_id(sizeof message_id, message_id);
 		from_address_size = (size_t)snprintf(from_address, sizeof from_address,
 			" from:<%.*s@" HOSTNAME ">", (int)username_size, username);
 		//this should be impossible


### PR DESCRIPTION
This PR overhauls how unique IDs are generated by the smtp program to make them more useful.

Instead of consisting of decimal values separated with periods, a fixed width hexadecimal format is adopted for easier parsing. The sub-values within the id are reordered so that the timestamp comes first followed by the pid followed by the sequence number so that sorting the values lexicographically produces a nice and sane ordering, and the timestamp is fetched once and cached at startup so that all ids generated by a given process will differ only in their sequence number.

The generic "sequence number" concept is split into a session number and then a unique id number within that session where sessions correspond to complete transactions from one user between logging in and executing `RSET` or `QUIT`. The log file containing the username and list of emails is always given the first id number within the session so that the unique id that refers to the overall session that a given email was part of can easily be determined from its unique id by simply replacing the sequence number with zero.