### PR TITLE
Regressions

### DIFF
--- a/nginx_snippets/server_https/01-error-pages.conf
+++ b/nginx_snippets/server_https/01-error-pages.conf
@@ -13,5 +13,6 @@ location @error {
 	proxy_pass_request_body off; # Don't send the original request body
 	proxy_pass_request_headers off; # Or the original headers
 	proxy_intercept_errors on; # If generating the page errors, try again with the new 502 error
+	proxy_set_header Cookie $http_cookie;
 	proxy_pass http://orbit:9098/error?num=$status;
 }

--- a/submatrix/Containerfile
+++ b/submatrix/Containerfile
@@ -6,7 +6,9 @@ COPY homeserver.yaml.template /etc/synapse/homeserver.yaml.template
 
 COPY homeserver.log.config /etc/synapse/homeserver.log.config
 
-COPY orbit_auth.py /usr/lib/python3.11/site-packages/orbit_auth.py
+COPY orbit_auth.py /usr/local/share/submatrix/
+
+COPY start.sh /usr/local/share/submatrix/
 
 ARG MATRIX_HOSTNAME=localhost
 
@@ -16,5 +18,5 @@ VOLUME /var/synapse
 
 USER 100:100
 
-CMD ["synapse_homeserver", "-c", "/etc/synapse/homeserver.yaml"]
+ENTRYPOINT ["/usr/local/share/submatrix/start.sh"]
 

--- a/submatrix/start.sh
+++ b/submatrix/start.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+export PYTHONPATH="/usr/local/share/submatrix:${PYTHONPATH}"
+exec synapse_homeserver -c /etc/synapse/homeserver.yaml


### PR DESCRIPTION
This branch contains fixes for two regressions in singularity functionality.

1) new builds of the submatrix container fail because of an update to the python version in alpine
2) navigating within the cgit generated pages consistently logs the user out.

Fixes: #115 