### PR TITLE
orbit: start.sh: use exec to make shutdown work correctly again

### DIFF
--- a/orbit/start.sh
+++ b/orbit/start.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 memcached --daemon --unix-socket /run/orbit/memcached.sock
-uwsgi --plugin 'python,http' ./radius.ini
+exec uwsgi --plugin 'python,http' ./radius.ini


### PR DESCRIPTION
using exec in the shell script will make uwsgi become pid 1 again which means that it can handle sigterm properly. The memcached daemon that is running in the background will be unceremoniously killed off when uwsgi exits, but this is not a problem because it (being a ram only cache) does not have persistent state.