### PR TITLE
Add support for dynamic class git repos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 cert*
 .*.sw*
 /docs
+/repos

--- a/cgit_repos/cgitrepos
+++ b/cgit_repos/cgitrepos
@@ -1,5 +1,0 @@
-enable-index-owner=0
-
-repo.url=Singularity
-repo.path=/var/git/singularity
-repo.desc=Repository containing all KDLP content and infrastructure.

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -168,6 +168,19 @@ services:
     networks:
       - denis
       - smtp
+  git:
+    build:
+      context: git
+      dockerfile: Containerfile
+      additional_contexts:
+        - git_singularity_git_dir=./.git
+        - git_course_repositories=repos
+    volumes:
+      - type: volume
+        source: git-repos
+        target: /var/lib/git/
+    ports:
+      - "8000"
 networks:
   orbit:
   smtp:
@@ -184,3 +197,4 @@ volumes:
   submissions-db:
   submatrix-data:
   denis-db:
+  git-repos:

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -37,9 +37,7 @@ services:
       context: orbit
       dockerfile: Containerfile
       additional_contexts:
-        - orbit_singularity_git_dir=./.git
         - orbit_docs_source=./docs
-        - orbit_repos_source=./cgit_repos
         - mailman_source=./mailman
       target: orbit
       args:
@@ -53,6 +51,12 @@ services:
         source: submissions-db
         target: /var/lib/mailman
         read_only: true
+      - type: volume
+        source: git-repos
+        target: /var/lib/git
+        read_only: true
+    depends_on:
+      - git
     networks:
       - orbit
   smtp:

--- a/git/Containerfile
+++ b/git/Containerfile
@@ -1,0 +1,54 @@
+FROM alpine:3.20 as git
+
+RUN apk update && apk upgrade && apk add \
+	python3 \
+	git \
+	git-daemon \
+	;
+
+RUN mkdir /usr/local/share/git
+
+WORKDIR /usr/local/share/git
+
+COPY ./gitconfig ./.gitconfig
+
+COPY ./hooks ./hooks
+
+COPY ./setup-repo.sh ./setup-repo.sh
+
+COPY ./create-repo.sh ./create-repo.sh
+
+RUN mkdir /var/lib/git/
+
+WORKDIR /var/lib/git/
+
+RUN mkdir singularity
+
+COPY --from=git_singularity_git_dir . singularity/
+
+RUN echo 'Repository containing all KDLP content and infrastructure.' > singularity/description
+
+COPY --from=git_course_repositories . .
+
+RUN for dir in $(ls); \
+	do \
+		if [ -d $dir/.git ]; \
+		then \
+			dir=$dir/.git; \
+		fi; \
+		/usr/local/share/git/setup-repo.sh $dir ; \
+	done
+
+
+
+COPY ./cgi-bin ./cgi-bin
+
+RUN chown -R 100:100 .
+
+USER 100:100
+
+VOLUME /var/lib/git/
+
+WORKDIR /usr/local/share/git
+
+CMD trap exit TERM; python -m http.server --directory /var/lib/git/ --cgi & wait

--- a/git/admin.sh
+++ b/git/admin.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+
+DOCKER_COMPOSE=${DOCKER_COMPOSE:-podman-compose}
+
+$DOCKER_COMPOSE exec git ./create-repo.sh "$@"

--- a/git/cgi-bin/git-receive-pack
+++ b/git/cgi-bin/git-receive-pack
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec git http-backend

--- a/git/create-repo.sh
+++ b/git/create-repo.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+set -e
+[ $# -ne 2 ] && { echo 'Usage: create-repo <name> <description>' >&2; exit 1; }
+
+REPO="/var/lib/git/$1"
+
+git init --bare "$REPO"
+echo "$2" > "$REPO/description"
+./setup-repo.sh "$REPO"

--- a/git/gitconfig
+++ b/git/gitconfig
@@ -1,0 +1,2 @@
+[core]
+	hooksPath=/var/lib/git/hooks/

--- a/git/hooks/post-update
+++ b/git/hooks/post-update
@@ -1,0 +1,2 @@
+#!/bin/sh
+exec git update-server-info

--- a/git/setup-repo.sh
+++ b/git/setup-repo.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -e
+[ -z "$1" ] && { echo 'must pass path to .git dir of repo' >&2; exit 1; }
+cd "$1" || { echo 'invalid repo' >&2; exit 1; }
+touch git-daemon-export-ok
+git config http.receivepack true
+git update-server-info

--- a/orbit/Containerfile
+++ b/orbit/Containerfile
@@ -32,8 +32,6 @@ WORKDIR /usr/local/share/orbit
 COPY --from=build /usr/local/share/orbit /usr/local/share/orbit
 COPY --from=orbit_docs_source . ./docs
 COPY --from=mailman_source . ./mailman
-COPY --from=orbit_singularity_git_dir . /var/git/singularity
-COPY --from=orbit_repos_source . /etc/cgit
 
 RUN mkdir -p /var/lib/orbit/ && \
 	./db.py \

--- a/orbit/cgitrc
+++ b/orbit/cgitrc
@@ -20,4 +20,5 @@ mimetype.svg=image/svg+xml
 
 virtual-root=/cgit
 
-include=/etc/cgit/cgitrepos
+enable-index-owner=0
+scan-path=/var/lib/git

--- a/script-lint.sh
+++ b/script-lint.sh
@@ -8,6 +8,11 @@ set -ex
 shellcheck script-lint.sh
 shellcheck test.sh
 shellcheck orbit/warpdrive.sh
+shellcheck git/admin.sh
+shellcheck git/create-repo.sh
+shellcheck git/setup-repo.sh
+shellcheck git/cgi-bin/git-receive-pack
+shellcheck git/hooks/post-update
 
 # -x needed to make shellcheck follow `source` command
 shellcheck -x backup/backup.sh


### PR DESCRIPTION
A new container manages the class git repos.

They are initialized with a copy of singularity and a copy of any other bare repos stored in a new `docs` like folder called `repos`, and stored in a volume for persistence.

It has a warpdrive like script that allows adding new repos on the fly and runs an http server with a port mapped to the host that can accept pushes to the repos so they can be synced to publish new content as the semester progresses.

CGIT now pulls its repo data from this container's volume in a readonly fashion to publish the repos (behind auth) for students to clone.