### PR TITLE
Record Peer Reviews

### DIFF
--- a/mailman/db.py
+++ b/mailman/db.py
@@ -19,5 +19,13 @@ class Submission(BaseModel):
     status = peewee.TextField()
 
 
+class PeerReview(BaseModel):
+    review_id = peewee.TextField(unique=True)
+    reviewer = peewee.TextField()
+    reviewee = peewee.TextField()
+    assignment = peewee.TextField()
+    timestamp = peewee.IntegerField()
+
+
 if __name__ == '__main__':
     DB.create_tables(BaseModel.__subclasses__())


### PR DESCRIPTION
-  Adds a new peer review table to mailman's submissions db
-  Performs some basic checks on single emails to make sure they are peer reviews
-  Assuming an email is a peer review, extracts relevant information and enters it into the new peer review db