### PR TITLE
orbit: logo link to kdlp.underground.software

### DIFF
--- a/orbit/header.html
+++ b/orbit/header.html
@@ -11,7 +11,9 @@
 	</head>
 	<body>
 		<div class="logo">
-			<img src="/images/kdlp_logo.png" class="logo" alt="[KDLP] logo" />
+			<a href="https://kdlp.underground.software">
+				<img src="/images/kdlp_logo.png" class="logo" alt="[KDLP] logo" />
+			</a>
 			<h1 class="title" >Kernel Development Learning Pipeline</h1>
 		</div>
 


### PR DESCRIPTION
kinda nice

also considered making the whole div link to the page but it's a bit awkward.

We could also add "KDLP home" and "Course home" to the navbar but this PR is here to get the convo rolling
