### PR TITLE
README.md flake8 fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ You will need the host program socat. On Fedora it can be obtained by running `s
  - Make sure to specify the protocol (https, smtps, pop3s) and port (443 or 1443, 465 or 1465, 995 or 1995) explicitly or your client may
 try to use the wrong port or the unencrypted version of the protocol.
 
- - There is no web content by default so the homepage of the website will give a 404 error, however the links  to the course
+ - There is no web content by default so the homepage of the website will give a 404 error, however the links to the course
 services in the navigation bar should work once signed in.
 
  - Once finished:

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Section 3: Testing and basic functionality
  - In order to verify that singularity is behaving correctly, you should run the test suite.
 
  - You will need to install some host packages needed by the testing script: flake8, shellcheck, jq, and curl.
-On Fedora these packages can be obtained by running `sudo dnf install -y flake8 shellcheck jq curl`.
+On Fedora these packages can be obtained by running `sudo dnf install -y python3-flake8 shellcheck jq curl`.
 
  - Now you can run `./test.sh`. If you followed the directions, the tests should pass.
 


### PR DESCRIPTION
Updated README to replace 'flake8' installation instruction with 'python3-flake8' for improved compatibility and clarity.