### PR TITLE
Add missing && to orbit/Containerfile

### DIFF
--- a/orbit/Containerfile
+++ b/orbit/Containerfile
@@ -36,7 +36,7 @@ COPY --from=mailman_source . ./mailman
 COPY --from=denis_source . ./denis
 
 RUN mkdir -p /var/lib/orbit/ && \
-	./db.py \
+	./db.py && \
 	:
 
 COPY cgitrc /etc/cgitrc


### PR DESCRIPTION
Added a trailing && to orbit/Containerfile to prevent the colon on the next line from being interpreted as an argument to ./db.py

Addresses issue #154 