### PR TITLE
orbit: use asbolute static asset/image links

### DIFF
--- a/orbit/header.html
+++ b/orbit/header.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html lang="en">
 	<head>
-		<link rel="stylesheet" type="text/css" href="/assets/style.css" />
-		<link rel="apple-touch-icon" sizes="180x180" href="/assets/apple-touch-icon.png" />
-		<link rel="icon" type="image/x-icon" href="/assets/favicon.ico" />
-		<link rel="manifest" href="/assets/site.webmanifest" />
+		<link rel="stylesheet" type="text/css" href="https://kdlp.underground.software/assets/style.css" />
+		<link rel="apple-touch-icon" sizes="180x180" href="https://kdlp.underground.software/assets/apple-touch-icon.png" />
+		<link rel="icon" type="image/x-icon" href="https://kdlp.underground.software/assets/favicon.ico" />
+		<link rel="manifest" href="https://kdlp.underground.software/assets/site.webmanifest" />
 		<meta charset="UTF-8" />
 		<meta name="viewport" content="width=device-width,initial-scale=1.0">
 		<title>KDLP</title>
@@ -12,7 +12,7 @@
 	<body>
 		<div class="logo">
 			<a href="https://kdlp.underground.software">
-				<img src="/images/kdlp_logo.png" class="logo" alt="[KDLP] logo" />
+				<img src="https://kdlp.underground.software/images/kdlp_logo.png" class="logo" alt="[KDLP] logo" />
 			</a>
 			<h1 class="title" >Kernel Development Learning Pipeline</h1>
 		</div>


### PR DESCRIPTION
We moved this content from ILKD_course_materials to kdlp.underground.software so we no longer retrieve this from the docs directory. Instead, we load it from our main website.

This also slightly simplifies deployment issues involving permissions errors when requesting static content.