### PR TITLE
Fixes the issue where fullname was required 

### DIFF
--- a/orbit/db.py
+++ b/orbit/db.py
@@ -15,7 +15,7 @@ class User(BaseModel):
     username = peewee.TextField(unique=True)
     pwdhash = peewee.TextField(null=True)
     student_id = peewee.TextField(unique=True, null=True)
-    fullname = peewee.TextField()
+    fullname = peewee.TextField(null=True)
 
 
 class Session(BaseModel):


### PR DESCRIPTION
Fixes #221. This fixes the issue where fullname was required even though the rest of the codebase assumes it can be NULL.

One limitation is that if the test script is run twice, it will still hit a UNIQUE constraint failed: user.student_id error, since test.sh tries to create a user with student_id = 1234, which already exists from the first run. This happens because the database persists between runs in the Podman volume. Clearing the volume before running the tests would prevent duplicate users from previous runs.

That said, this change should at least resolve the NOT NULL constraint failed: user.fullname issue!