### PR TITLE
CI: move code into singularity repo

### DIFF
--- a/.github/workflows/circumference-test-container.yaml
+++ b/.github/workflows/circumference-test-container.yaml
@@ -22,12 +22,10 @@ jobs:
         sudo apt install -y podman
         podman --version
 
-    - name: Clone circumference and start PINPing
+    - name: Start PINPing
       id: run_tests
       run: |
-        git clone https://github.com/underground-software/circumference ../circumference
-        cd ../circumference
-        podman build --build-context=singularity_git_repo=$OLDPWD -t singularity-test .
+        podman build --build-context=singularity_git_repo=. -t singularity-test .
         podman run --rm --privileged localhost/singularity-test:latest
 
     - name: Report test results

--- a/Containerfile
+++ b/Containerfile
@@ -1,0 +1,25 @@
+FROM fedora:latest
+
+RUN dnf update -y && \
+	dnf install -y \
+	podman \
+	podman-compose \
+	jq \
+	ShellCheck \
+	which \
+	python-flake8 \
+	python-virtualenv \
+	python-pip \
+	git
+
+RUN sed -i 's/log_driver = "journald"/log_driver = "json-file"/' /usr/share/containers/containers.conf
+
+COPY --from=singularity_git_repo . ./singularity
+
+RUN mkdir -p singularity/{repos,docs}
+
+COPY start.sh .
+
+WORKDIR singularity
+
+ENTRYPOINT ["/start.sh"]

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+set -ex
+
+mkdir -p /var/lib/containers/storage
+mount -t tmpfs tmpfs /var/lib/containers/storage
+podman-compose build
+podman-compose up -d
+# wait until synapse is done initializing
+podman-compose logs -f submatrix 2>&1 | sed '/Synapse now listening on TCP port 8008/ q'
+if [ -f test.sh ]
+then
+	./test.sh
+else
+	virtualenv .
+	pip install -r requirements.txt
+	pytest
+fi
+podman-compose down


### PR DESCRIPTION
There is no reason for circumference to be involved here, it just makes it easier to break CI if the two repos end up out of sync. We learned this lesson the last time we did something other than monorepo.