### PR TITLE
mailman: commit raw patches when patchset is corrupt

### DIFF
--- a/mailman/patchset.py
+++ b/mailman/patchset.py
@@ -89,6 +89,11 @@ def do_check(repo_path, cover_letter, patches):
 def check(cover_letter, patches, submission_id):
     with tempfile.TemporaryDirectory() as repo_path:
         status = do_check(repo_path, cover_letter, patches)
+        if status[-1] == '!':
+            repo = git.Repo(repo_path)
+            for patch in patches:
+                patch_abspath = str(maildir / patch.msg_id)
+                repo.git.execute(['git', *author_args, 'commit', '--allow-empty', '-F', patch_abspath])
         tag_and_push(repo_path, submission_id)
     return status
 

--- a/mailman/patchset.py
+++ b/mailman/patchset.py
@@ -49,13 +49,13 @@ def do_check(repo_path, cover_letter, patches):
 
     if try_or_false(lambda: am_cover_letter(keep_empty=False),
                     git.GitCommandError):
-        return "missing cover letter"
+        return "missing cover letter!"
 
     repo.git.execute(["git", *author_args, "am", "--abort"])
     if not try_or_false(lambda: am_cover_letter(keep_empty=True),
                         git.GitCommandError):
         return ("missing cover letter and "
-                "first patch failed to apply")
+                "first patch failed to apply!")
 
     for i, patch in enumerate(patches):
         patch_abspath = str(maildir / patch.msg_id)
@@ -77,13 +77,13 @@ def do_check(repo_path, cover_letter, patches):
             continue
 
         # If we still fail, the patch does not apply
-        return f'patch {i+1} failed to apply'
+        return f'patch {i+1} failed to apply!'
 
     if whitespace_errors:
         return ('whitespace error patch(es) '
-                f'{",".join(whitespace_errors)}')
+                f'{",".join(whitespace_errors)}?')
     else:
-        return 'patchset applies'
+        return 'patchset applies.'
 
 
 def check(cover_letter, patches, submission_id):

--- a/mailman/patchset.py
+++ b/mailman/patchset.py
@@ -7,6 +7,7 @@ REMOTE_PUSH_URL = 'http://git:8000/cgi-bin/git-receive-pack/grading.git'
 REMOTE_PULL_URL = 'http://git:8000/grading.git'
 
 MAIL_DIR_ABSPATH = "/var/lib/email/mail"
+maildir = pathlib.Path(MAIL_DIR_ABSPATH)
 
 
 def try_or_false(do, exc):
@@ -38,7 +39,6 @@ git_am_args = ['git', '-c', 'advice.mergeConflict=false',
 
 def do_check(repo_path, cover_letter, patches):
     repo = git.Repo.init(repo_path)
-    maildir = pathlib.Path(MAIL_DIR_ABSPATH)
     whitespace_errors = []
 
     def am_cover_letter(keep_empty=True):
@@ -94,7 +94,6 @@ def check(cover_letter, patches, submission_id):
 
 
 def apply_peer_review(email, submission_id, review_id):
-    maildir = pathlib.Path(MAIL_DIR_ABSPATH)
     args = [*git_am_args, '--empty=keep']
     patch_abspath = str(maildir / email.msg_id)
 


### PR DESCRIPTION
When a student submits a corrupt patchset, only the cover letter makes it to the grading repository so if an instructor wishes to examine the patch they must dig into the containers and find the email file.

When mailman fails to apply a patch, the email patch file and all subsequent patchset in the patchset are committed to the repository as files and the resulting tag will contain these commits.

Fixes: #251