### PR TITLE
Immediate automated feedback and grades on course dashboard and beginning of automated denis checks

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,7 +10,10 @@ RUN dnf update -y && \
 	python-flake8 \
 	python-virtualenv \
 	python-pip \
-	git
+	gawk \
+	socat \
+	git \
+	git-email
 
 RUN sed -i 's/log_driver = "journald"/log_driver = "json-file"/' /usr/share/containers/containers.conf
 

--- a/container-compose.yml
+++ b/container-compose.yml
@@ -185,6 +185,7 @@ services:
         - orbit_source=./orbit
     environment:
       TZ: ${SINGULARITY_TIMEZONE}
+      HOSTNAME: ${SINGULARITY_HOSTNAME}
     volumes:
       - type: volume
         source: denis-db

--- a/create_rubric.py
+++ b/create_rubric.py
@@ -1,0 +1,24 @@
+#!/bin/env python
+
+from argparse import ArgumentParser as ap
+import git
+import os
+
+
+def main():
+    parser = ap(prog='create_rubric', description='create rubric')
+    parser.add_argument('-n', type=int, help='number of patches to examine',
+                        required=True)
+
+    args = parser.parse_args()
+
+    repo = git.Repo(os.getcwd())
+    for i in range(args.n):
+        patch = repo.git.execute(['git', 'show', f'HEAD~{args.n-i-1}'])
+        changelines = list(filter(lambda line: line.startswith('--- ') or line.startswith('+++ '), patch.split('\n')))
+        changeline_pairs = {(fromfile, tofile): 0 for fromfile, tofile in zip(changelines[::2], changelines[1::2])}
+        print(f'{"[" if i == 0 else ""}{changeline_pairs}{"," if i < args.n - 1 else "]"}')
+
+
+if __name__ == '__main__':
+    main()

--- a/denis/configure.sh
+++ b/denis/configure.sh
@@ -1,7 +1,31 @@
 #!/bin/sh
 set -e
 
+PODMAN=${PODMAN:-podman}
 COMPOSE=${COMPOSE:-podman-compose}
+
+# a rubric is passed as a path to a file,
+# but the main script is executed inside the container
+# so copy any rubric into the container,
+# if one is specified.
+get_next=
+rubric_file=
+for arg in "$@"
+do
+	if [ "$arg" = '-r' ]
+	then
+		get_next=yes
+	elif [ -n "$get_next" ]
+	then
+		rubric_file=$arg
+	fi
+done
+
+if [ -n "$rubric_file" ]
+then
+	${PODMAN} cp "$rubric_file" singularity_denis_1:/tmp/rubric
+fi
+
 
 ${COMPOSE} exec denis ./configure.py "$@"
 

--- a/denis/db.py
+++ b/denis/db.py
@@ -15,6 +15,7 @@ class Assignment(BaseModel):
     initial_due_date = peewee.IntegerField()
     peer_review_due_date = peewee.IntegerField()
     final_due_date = peewee.IntegerField()
+    rubric = peewee.TextField(null=True)
 
 
 class PeerReviewAssignment(BaseModel):

--- a/denis/final.py
+++ b/denis/final.py
@@ -11,4 +11,6 @@ utilities.release_subs([sub for sub in
 
 print(f'final subs for {assignment} released')
 
-utilities.update_tags(assignment, 'final')
+tags = utilities.update_tags(assignment, 'final')
+
+utilities.run_automated_checks(tags)

--- a/denis/initial.py
+++ b/denis/initial.py
@@ -58,4 +58,6 @@ utilities.release_subs([sub for sub in usernames_to_subs.values() if sub])
 
 print(f'initial subs for {assignment} released')
 
-utilities.update_tags(assignment, 'initial')
+tags = utilities.update_tags(assignment, 'initial')
+
+utilities.run_automated_checks(tags)

--- a/denis/peer_review.py
+++ b/denis/peer_review.py
@@ -14,5 +14,7 @@ utilities.release_subs(ids)
 
 print(f'peer review subs for {assignment} released')
 
-utilities.update_tags(assignment, 'review1')
-utilities.update_tags(assignment, 'review2')
+tags1 = utilities.update_tags(assignment, 'review1')
+tags2 = utilities.update_tags(assignment, 'review2')
+
+utilities.run_automated_checks(tags1 + tags2, peer=True)

--- a/denis/utilities.py
+++ b/denis/utilities.py
@@ -1,3 +1,5 @@
+import re
+import os
 import git
 import subprocess
 import tempfile
@@ -108,6 +110,45 @@ def check_corrupt_or_missing(repo, tag):
     return msg
 
 
+def check_signed_off_by(repo, tag):
+    [_, _, user] = tag.split('_')
+    hostname = os.getenv("HOSTNAME")
+
+    msg = 'signed off by check'
+    msg += '\n'
+    msg += '-------------------'
+    msg += '\n\n'
+
+    commits = reversed(repo.git.execute(['git', 'rev-list', tag]).split('\n'))
+
+    expected_dco = f'Signed-off-by: {user} <{user}@{hostname}>'
+
+    missing = []
+    malformed = []
+    for i, commit in enumerate(commits):
+        patch = repo.git.execute(['git', 'show', commit])
+
+        match = re.search(r'^\s+(Signed-off-by:\s+.+\s+<.+>)$', patch, re.MULTILINE)
+        if match:
+            found_dco = match.group(1)
+            if expected_dco == found_dco:
+                continue
+            malformed.append(f'malformed line {found_dco} in patch {i}\n')
+        else:
+            missing.append(f'{i}')
+
+    if (n := len(missing)) > 0:
+        msg += f'Signed-off-by: missing from patch{"es" if n > 1 else ""} {",".join(missing)}\n'
+    for mal in malformed:
+        msg += mal
+
+    if len(missing) == len(malformed) == 0:
+        msg += 'ALL PATCHES SIGNED OFF CORRECTLY\n'
+
+    msg += '\n'
+    return msg
+
+
 def check_diffstat(repo, tag):
     msg = 'diffstat check'
     msg += '\n'
@@ -158,6 +199,7 @@ def run_automated_checks(tags):
             if msg[-3] != '!':
                 msg += '\n\n'
                 msg += check_diffstat(repo, tag)
+                msg += check_signed_off_by(repo, tag)
 
             repo.git.execute(['git', 'notes', '--ref=denis', 'add', tag, '-m', msg])
 

--- a/denis/utilities.py
+++ b/denis/utilities.py
@@ -1,6 +1,7 @@
 import git
 import subprocess
 import tempfile
+import difflib
 
 import orbit.db
 import mailman.db
@@ -107,6 +108,40 @@ def check_corrupt_or_missing(repo, tag):
     return msg
 
 
+def check_diffstat(repo, tag):
+    msg = 'diffstat check'
+    msg += '\n'
+    msg += '--------------'
+    msg += '\n\n'
+
+    root = repo.git.execute(['git', 'rev-list', '--max-parents=0', tag])
+    calculated_diffstat = repo.git.execute(['git', 'diff', '--stat', '--summary', f'{root}..{tag}'])
+    cover = repo.git.execute(['git', 'show', root])
+    cover_lines = [line.strip() for line in cover.split('\n')]
+
+    rev_diffstat = []
+    last = None
+    collect = False
+    for i in reversed(cover_lines):
+        if collect:
+            if len(i) == 0:
+                break
+            rev_diffstat.append(f' {i}')
+        if len(i) == 0 and last == '--':
+            collect = True
+        last = i
+
+    cover_diffstat = '\n'.join(reversed(rev_diffstat))
+    diff_diffstat = '\n'.join(difflib.unified_diff(calculated_diffstat.split(), cover_diffstat.split()))
+
+    msg += 'diffstat diff'
+    msg += '\n'
+    msg += diff_diffstat if len(diff_diffstat) > 0 else 'NO DIFFERENCE: DIFFSTAT VERIFIED'
+    msg += '\n\n'
+
+    return msg
+
+
 def run_automated_checks(tags):
     with tempfile.TemporaryDirectory() as repo_path:
         repo = git.Repo.clone_from(PULL_URL, repo_path)
@@ -119,7 +154,11 @@ def run_automated_checks(tags):
             msg = 'Automated tests by denis'
             msg += '\n\n'
             msg += check_corrupt_or_missing(repo, tag)
-            # stop if corrupt (msg[-1] == '!')
+
+            if msg[-3] != '!':
+                msg += '\n\n'
+                msg += check_diffstat(repo, tag)
+
             repo.git.execute(['git', 'notes', '--ref=denis', 'add', tag, '-m', msg])
 
         remote.push('refs/notes/*:refs/notes/*')

--- a/denis/utilities.py
+++ b/denis/utilities.py
@@ -50,7 +50,7 @@ def configure_repo(repo):
 
 def update_tags(assignment, component):
     grd_tbl = mailman.db.Gradeable
-    subs = (grd_tbl.select()
+    gbls = (grd_tbl.select()
                    .order_by(-grd_tbl.timestamp)
                    .where(grd_tbl.assignment == assignment)
                    .where(grd_tbl.component == component))
@@ -70,12 +70,12 @@ def update_tags(assignment, component):
                 print('Potential issue? Attempted to create duplicate tag '
                       f'{new_tag_name}')
                 continue
-            user_sub = subs.where(grd_tbl.user == user.username).first()
-            if not user_sub or (id := user_sub.submission_id) not in repo.tags:
+            user_gbl = gbls.where(grd_tbl.user == user.username).first()
+            if not user_gbl or (id := user_gbl.submission_id) not in repo.tags:
                 msg = 'No gradeable submission'
                 to_promote = repo.tags['EMPTY']
             else:
-                msg = user_sub.status
+                msg = user_gbl.auto_feedback
                 to_promote = repo.tags[id]
             repo.create_tag(new_tag_name, ref=to_promote.commit, message=msg)
 
@@ -98,7 +98,7 @@ def check_corrupt_or_missing(repo, tag):
     msg += '\n'
     msg += '------------------------------'
     msg += '\n\n'
-    if not gradable or gradable.status[-1] == '!':
+    if not gradable or gradable.auto_feedback[-1] == '!':
         repo.git.execute(['git', 'notes', '--ref=grade', 'add', tag, '-m', '0'])
         if not gradable:
             msg += 'automatic 0 due to missing submission!'

--- a/denis/utilities.py
+++ b/denis/utilities.py
@@ -249,7 +249,7 @@ def check_subject_tag(repo, tag):
     return msg
 
 
-def run_automated_checks(tags):
+def run_automated_checks(tags, peer=False):
     with tempfile.TemporaryDirectory() as repo_path:
         repo = git.Repo.clone_from(PULL_URL, repo_path)
 
@@ -262,7 +262,7 @@ def run_automated_checks(tags):
             msg += '\n\n'
             msg += check_corrupt_or_missing(repo, tag)
 
-            if msg[-3] != '!':
+            if msg[-3] != '!' and not peer:
                 msg += '\n\n'
                 msg += check_diffstat(repo, tag)
                 msg += check_signed_off_by(repo, tag)

--- a/denis/utilities.py
+++ b/denis/utilities.py
@@ -1,6 +1,7 @@
 import re
 import os
 import git
+import copy
 import subprocess
 import tempfile
 import difflib
@@ -183,6 +184,71 @@ def check_diffstat(repo, tag):
     return msg
 
 
+def check_subject_tag(repo, tag):
+    [_, component, _] = tag.split('_')
+
+    msg = 'subject tag check'
+    msg += '\n'
+    msg += '-----------------'
+    msg += '\n\n'
+
+    commits = reversed(repo.git.execute(['git', 'rev-list', tag]).split('\n'))
+    # from 0/n .. n/n
+    expected_max_index = str(len(list(copy.copy(commits))) - 1)
+
+    rfc_offset = 0
+    found_version = None
+    bad = {}
+    for i, commit in enumerate(commits):
+        patch = repo.git.execute(['git', 'show', commit])
+
+        match = re.search(r'^\s*\[(.*)\].*', patch, re.MULTILINE)
+        if not match:
+            msg += f'patch {i} no tag found!\n'
+            bad[i] = True
+            continue
+        subj_tag = match.group(1)
+        msg += f'patch {i} tag {subj_tag}\n'
+        subj_tag_parts = subj_tag.split(' ')
+        match component:
+            case 'initial' if subj_tag_parts[0] == 'RFC':
+                msg += 'initial submission correctly labeled RFC\n'
+                rfc_offset = 1
+            case 'initial' if subj_tag_parts[0] == 'PATCH':
+                msg += 'initial submission missing RFC!\n'
+                bad[i] = True
+            case 'final' if subj_tag_parts[0] == 'RFC':
+                msg += 'final submission incorrectly labeled RFC!\n'
+                rfc_offset = 1
+                bad[i] = True
+            case 'final' if subj_tag_parts[0] == 'PATCH':
+                msg += 'final submission correctly non RFC\n'
+
+        if subj_tag_parts[rfc_offset] != 'PATCH':
+            msg += 'tag missing "PATCH" in expected place\n'
+            bad[i] = True
+
+        if found_version is None:
+            found_version = subj_tag_parts[rfc_offset+1]
+        elif (this_version := subj_tag_parts[rfc_offset+1]) != found_version:
+            msg += f'tag version mismatch: expected {found_version} found {this_version}!\n'
+            bad[i] = True
+
+        [this_index, max_index] = subj_tag_parts[rfc_offset+2].split('/')
+        if this_index != str(i):
+            msg += f'patch index mismatch: expected {i} found {this_index}'
+            bad[i] = True
+
+        if max_index != expected_max_index:
+            msg += f'patch max index mismatch: expected {expected_max_index} found {max_index}'
+            bad[i] = True
+
+    if not any(bad):
+        msg += 'ALL SUBJECT TAGS IN CORRECT FORMAT\n'
+
+    return msg
+
+
 def run_automated_checks(tags):
     with tempfile.TemporaryDirectory() as repo_path:
         repo = git.Repo.clone_from(PULL_URL, repo_path)
@@ -200,6 +266,7 @@ def run_automated_checks(tags):
                 msg += '\n\n'
                 msg += check_diffstat(repo, tag)
                 msg += check_signed_off_by(repo, tag)
+                msg += check_subject_tag(repo, tag)
 
             repo.git.execute(['git', 'notes', '--ref=denis', 'add', tag, '-m', msg])
 

--- a/git/admin.sh
+++ b/git/admin.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 set -e
 
-DOCKER_COMPOSE=${DOCKER_COMPOSE:-podman-compose}
+PODMAN_COMPOSE=${PODMAN_COMPOSE:-podman-compose}
 
-$DOCKER_COMPOSE exec git ./create-repo.sh "$@"
+$PODMAN_COMPOSE exec git ./create-repo.sh "$@"

--- a/mailman/db.py
+++ b/mailman/db.py
@@ -27,7 +27,7 @@ class Gradeable(BaseModel):
     user = peewee.TextField()
     assignment = peewee.TextField()
     component = peewee.TextField()
-    status = peewee.TextField(null=True)
+    auto_feedback = peewee.TextField(null=True)
 
 
 if __name__ == '__main__':

--- a/mailman/inspector.py
+++ b/mailman/inspector.py
@@ -78,7 +78,7 @@ def gradables(assignment, username, component):
     for gbl in query:
         print(gbl.submission_id,
               datetime.fromtimestamp(gbl.timestamp).astimezone().isoformat(),
-              gbl.assignment, gbl.user, gbl.component, gbl.status)
+              gbl.assignment, gbl.user, gbl.component, gbl.auto_feedback)
 
 
 def missing(assignment):

--- a/mailman/patchset.py
+++ b/mailman/patchset.py
@@ -80,7 +80,7 @@ def do_check(repo_path, cover_letter, patches):
         return f'patch {i+1} failed to apply!'
 
     if whitespace_errors:
-        return ('whitespace error patch(es) '
+        return (f'whitespace error patch{"es" if len(whitespace_errors) > 1 else ""} '
                 f'{",".join(whitespace_errors)}?')
     else:
         return 'patchset applies.'

--- a/mailman/patchset.py
+++ b/mailman/patchset.py
@@ -19,9 +19,9 @@ def try_or_false(do, exc):
         return False
 
 
-def tag_and_push(repo, tag_name):
+def tag_and_push(repo, tag_name, msg=None):
     try:
-        repo.create_tag(tag_name)
+        repo.create_tag(tag_name, message=msg)
         repo.create_remote('grading', REMOTE_PUSH_URL)
         repo.git.push('grading', tags=True)
         return True
@@ -93,7 +93,7 @@ def check(cover_letter, patches, submission_id):
             for patch in patches:
                 patch_abspath = str(maildir / patch.msg_id)
                 repo.git.execute(['git', 'commit', '--allow-empty', '-F', patch_abspath])
-        tag_and_push(repo, submission_id)
+        tag_and_push(repo, submission_id, msg=status)
     return status
 
 

--- a/mailman/patchset.py
+++ b/mailman/patchset.py
@@ -19,9 +19,8 @@ def try_or_false(do, exc):
         return False
 
 
-def tag_and_push(repo_path, tag_name):
+def tag_and_push(repo, tag_name):
     try:
-        repo = git.Repo(repo_path)
         repo.create_tag(tag_name)
         repo.create_remote('grading', REMOTE_PUSH_URL)
         repo.git.push('grading', tags=True)
@@ -37,8 +36,7 @@ git_am_args = ['git', '-c', 'advice.mergeConflict=false',
                *author_args, 'am', '--keep']
 
 
-def do_check(repo_path, cover_letter, patches):
-    repo = git.Repo.init(repo_path)
+def do_check(repo, cover_letter, patches):
     whitespace_errors = []
 
     def am_cover_letter(keep_empty=True):
@@ -88,9 +86,9 @@ def do_check(repo_path, cover_letter, patches):
 
 def check(cover_letter, patches, submission_id):
     with tempfile.TemporaryDirectory() as repo_path:
-        status = do_check(repo_path, cover_letter, patches)
+        repo = git.Repo.init(repo_path)
+        status = do_check(repo, cover_letter, patches)
         if status[-1] == '!':
-            repo = git.Repo(repo_path)
             for patch in patches:
                 patch_abspath = str(maildir / patch.msg_id)
                 repo.git.execute(['git', *author_args, 'commit', '--allow-empty', '-F', patch_abspath])
@@ -111,7 +109,7 @@ def apply_peer_review(email, submission_id, review_id):
                                                       '--single-branch',
                                                       '--no-tags'])
             repo.git.execute([*args, patch_abspath])
-            tag_and_push(repo_path, submission_id)
+            tag_and_push(repo, submission_id)
         except git.GitCommandError as e:
             print(e, file=sys.stderr)
             status = 'failed to apply peer review'

--- a/mailman/patchset.py
+++ b/mailman/patchset.py
@@ -30,10 +30,8 @@ def tag_and_push(repo, tag_name):
         return False
 
 
-author_args = ['-c', 'user.name=mailman', '-c',
-               'user.email=mailman@mailman']
 git_am_args = ['git', '-c', 'advice.mergeConflict=false',
-               *author_args, 'am', '--keep']
+               'am', '--keep']
 
 
 def do_check(repo, cover_letter, patches):
@@ -49,7 +47,7 @@ def do_check(repo, cover_letter, patches):
                     git.GitCommandError):
         return "missing cover letter!"
 
-    repo.git.execute(["git", *author_args, "am", "--abort"])
+    repo.git.execute(["git", "am", "--abort"])
     if not try_or_false(lambda: am_cover_letter(keep_empty=True),
                         git.GitCommandError):
         return ("missing cover letter and "
@@ -67,7 +65,7 @@ def do_check(repo, cover_letter, patches):
                         git.GitCommandError):
             continue
 
-        repo.git.execute(["git", *author_args, "am", "--abort"])
+        repo.git.execute(["git", "am", "--abort"])
 
         # Try again, if we succeed, count this patch as a whitespace error
         if try_or_false(lambda: do_git_am(), git.GitCommandError):
@@ -87,12 +85,15 @@ def do_check(repo, cover_letter, patches):
 def check(cover_letter, patches, submission_id):
     with tempfile.TemporaryDirectory() as repo_path:
         repo = git.Repo.init(repo_path)
+        with repo.config_writer() as config:
+            config.set_value('user', 'name', 'mailman')
+            config.set_value('user', 'email', 'mailman@mailman')
         status = do_check(repo, cover_letter, patches)
         if status[-1] == '!':
             for patch in patches:
                 patch_abspath = str(maildir / patch.msg_id)
-                repo.git.execute(['git', *author_args, 'commit', '--allow-empty', '-F', patch_abspath])
-        tag_and_push(repo_path, submission_id)
+                repo.git.execute(['git', 'commit', '--allow-empty', '-F', patch_abspath])
+        tag_and_push(repo, submission_id)
     return status
 
 
@@ -108,6 +109,9 @@ def apply_peer_review(email, submission_id, review_id):
                                        multi_options=[f'--branch={review_id}',
                                                       '--single-branch',
                                                       '--no-tags'])
+            with repo.config_writer() as config:
+                config.set_value('user', 'name', 'mailman')
+                config.set_value('user', 'email', 'mailman@mailman')
             repo.git.execute([*args, patch_abspath])
             tag_and_push(repo, submission_id)
         except git.GitCommandError as e:

--- a/mailman/patchset.py
+++ b/mailman/patchset.py
@@ -143,20 +143,20 @@ def check(cover_letter, patches, submission_id, asn):
         with repo.config_writer() as config:
             config.set_value('user', 'name', 'mailman')
             config.set_value('user', 'email', 'mailman@mailman')
-        status = do_check(repo, cover_letter, patches, asn)
-        if status[-1] == '!':
+        auto_feedback = do_check(repo, cover_letter, patches, asn)
+        if auto_feedback[-1] == '!':
             for patch in patches:
                 patch_abspath = str(maildir / patch.msg_id)
                 repo.git.execute(['git', 'commit', '--allow-empty', '-F', patch_abspath])
-        tag_and_push(repo, submission_id, msg=status)
-    return status
+        tag_and_push(repo, submission_id, msg=auto_feedback)
+    return auto_feedback
 
 
 def apply_peer_review(email, submission_id, review_id):
     args = [*git_am_args, '--empty=keep']
     patch_abspath = str(maildir / email.msg_id)
 
-    status = 'sucessfully stored peer review'
+    auto_feedback = 'sucessfully stored peer review'
 
     with tempfile.TemporaryDirectory() as repo_path:
         try:
@@ -171,6 +171,6 @@ def apply_peer_review(email, submission_id, review_id):
             tag_and_push(repo, submission_id)
         except git.GitCommandError as e:
             print(e, file=sys.stderr)
-            status = 'failed to apply peer review'
+            auto_feedback = 'failed to apply peer review'
 
-    return status
+    return auto_feedback

--- a/mailman/submit.py
+++ b/mailman/submit.py
@@ -65,7 +65,7 @@ def main(argv):
     gr_db = db.Gradeable
     if asn := asn_db.get_or_none(asn_db.name == emails[0].rcpt):
         cover_letter, *patches = emails
-        status = patchset.check(cover_letter, patches, logfile)
+        status = patchset.check(cover_letter, patches, logfile, asn)
         if len(emails) < 2:
             return set_status('missing patches')
         typ = ('initial' if timestamp < asn.initial_due_date

--- a/orbit/Containerfile
+++ b/orbit/Containerfile
@@ -18,6 +18,7 @@ FROM alpine:3.20 AS orbit
 
 RUN apk update && apk upgrade && apk add \
 	py3-bcrypt \
+	py3-gitpython \
 	py3-peewee \
 	py3-markdown \
 	uwsgi-python3 \

--- a/orbit/radius.py
+++ b/orbit/radius.py
@@ -476,6 +476,14 @@ class AsmtTable:
             case _:
                 return '---'
 
+    def get_human_feedback(self):
+        tag = f'{self.name}_final_{self.user}'
+        repo = git.Repo('/var/lib/git/grading.git')
+        try:
+            return repo.git.execute(['git', 'notes', '--ref=feedback', 'show', tag])
+        except git.GitCommandError:
+            return '-'
+
     def get_grade(self, attr):
         tag = f'{self.name}_{attr}_{self.user}'
         repo = git.Repo('/var/lib/git/grading.git')
@@ -546,6 +554,10 @@ class AsmtTable:
                 <th>Automated Feedback</th>
                 <td colspan="3">{self.get_automated_feedback('final')}</td>
               </tr>
+              <tr>
+                <th>Human Feedback</th>
+                <td colspan="3">{self.get_human_feedback()}</td>
+              </tr>
             """
         if (not self.init or
             (int(datetime.now().timestamp())
@@ -575,6 +587,10 @@ class AsmtTable:
           <tr>
             <th>Automated Feedback</th>
             <td colspan="3">{self.get_automated_feedback('final')}</td>
+          </tr>
+          <tr>
+            <th>Human Feedback</th>
+            <td colspan="3">{self.get_human_feedback()}</td>
           </tr>
         """
 

--- a/orbit/radius.py
+++ b/orbit/radius.py
@@ -4,6 +4,7 @@
 
 import base64
 import bcrypt
+import git
 import html
 import markdown
 import os
@@ -471,6 +472,17 @@ class AsmtTable:
             case _:
                 return '---'
 
+    def get_grade(self):
+        if self.final is None:
+            return '-'
+        tag = f'{self.final.assignment}_final_{self.final.user}'
+        repo = git.Repo('/var/lib/git/grading.git')
+        try:
+            grade = repo.git.execute(['git', 'notes', '--ref=grade', 'show', tag])
+            return grade
+        except git.GitCommandError:
+            return '-'
+
     def gradeable_row(self, item_name, gradeable, rightmost_col):
         return f"""
         <tr>
@@ -531,7 +543,7 @@ class AsmtTable:
           </tr>
           {self.gradeable_row(self.peer1 + ' Peer Review', self.review1, '-') if self.peer1 else ''}
           {self.gradeable_row(self.peer2 + ' Peer Review', self.review2, '-') if self.peer2 else ''}
-          {self.gradeable_row('Final Submission', self.final, '-')}
+          {self.gradeable_row('Final Submission', self.final, self.get_grade())}
           <tr>
             <th>Automated Feedback</th>
             <td colspan="3">{self.get_automated_feedback('final')}</td>

--- a/orbit/radius.py
+++ b/orbit/radius.py
@@ -489,6 +489,24 @@ class AsmtTable:
         except git.GitCommandError:
             return '-'
 
+    def get_total_score(self):
+        oopsie_used_here = self.oopsieness == OopsStatus.USED_HERE
+        final_grade = self.get_grade('final')
+
+        if oopsie_used_here:
+            return final_grade
+
+        review1_grade = self.get_grade('review1')
+        review2_grade = self.get_grade('review2')
+
+        if '-' in [final_grade, review1_grade, review2_grade]:
+            return '-'
+
+        try:
+            return format(int(final_grade) * .8 + int(review1_grade) * .1 + int(review2_grade) * .1, '.1f')
+        except ValueError:
+            return "???"
+
     def gradeable_row(self, item_name, gradeable, rightmost_col):
         return f"""
         <tr>
@@ -561,7 +579,7 @@ class AsmtTable:
         <table>
           <caption><h3>{self.name}</h3></caption>
           <tr>
-            <th>Total Score: -</th>
+            <th>Total Score: {self.get_total_score()}</th>
             <th>Timestamp</th>
             <th>Submission ID</th>
             <th>Request an 'Oopsie'</th>

--- a/orbit/radius.py
+++ b/orbit/radius.py
@@ -448,6 +448,29 @@ class AsmtTable:
             case OopsStatus.UNAVAILABLE:
                 return "You have already used your oopsie"
 
+    def get_automated_feedback(self, attr):
+        if attr not in ['init', 'final'] or (gbl := getattr(self, attr)) is None:
+            return 'No submission'
+
+        match attr:
+            case 'init':
+                due_date = int(self.assignment.initial_due_date)
+            case 'final':
+                due_date = int(self.assignment.final_due_date)
+
+        if due_date < int(datetime.now().timestamp()):
+            return gbl.status
+
+        match gbl.status[-1]:
+            case '.':
+                return 'Submission accepted'
+            case '?':
+                return 'Issues detected in patchset'
+            case '!':
+                return 'Submission rejected'
+            case _:
+                return '---'
+
     def gradeable_row(self, item_name, gradeable, rightmost_col):
         return f"""
         <tr>
@@ -480,8 +503,8 @@ class AsmtTable:
             return f"""
               {self.gradeable_row('Final Submission', self.final, self.oopsie_button())}
               <tr>
-                <th>Comments</th>
-                <td colspan="3">-</td>
+                <th>Automated Feedback</th>
+                <td colspan="3">{self.get_automated_feedback('final')}</td>
               </tr>
             """
         if (not self.init or
@@ -491,14 +514,14 @@ class AsmtTable:
               {self.gradeable_row('Initial Submission', self.init, self.oopsie_button())}
               <tr>
                 <th>Automated Feedback</th>
-                <td colspan="3">-</td>
+                <td colspan="3">{self.get_automated_feedback('init')}</td>
               </tr>
             """
         return f"""
           {self.gradeable_row('Initial Submission', self.init, self.oopsie_button())}
           <tr>
             <th>Automated Feedback</th>
-            <td colspan="3">-</td>
+            <td colspan="3">{self.get_automated_feedback('init')}</td>
           </tr>
           <tr>
             <th></th>
@@ -510,8 +533,8 @@ class AsmtTable:
           {self.gradeable_row(self.peer2 + ' Peer Review', self.review2, '-') if self.peer2 else ''}
           {self.gradeable_row('Final Submission', self.final, '-')}
           <tr>
-            <th>Comments</th>
-            <td colspan="3">-</td>
+            <th>Automated Feedback</th>
+            <td colspan="3">{self.get_automated_feedback('final')}</td>
           </tr>
         """
 

--- a/orbit/radius.py
+++ b/orbit/radius.py
@@ -436,6 +436,9 @@ class AsmtTable:
         self.review1 = review1
         self.review2 = review2
         self.final = final
+        self.review1_grade = None
+        self.review2_grade = None
+        self.final_grade = None
 
     def oops_button_hover(self):
         match self.oopsieness:
@@ -475,10 +478,13 @@ class AsmtTable:
     def get_grade(self, attr):
         if attr not in ['final', 'review1', 'review2'] or (gbl := getattr(self, attr)) is None:
             return '-'
+        if (cached_grade := getattr(self, f'{attr}_grade')) is not None:
+            return cached_grade
         tag = f'{gbl.assignment}_{attr}_{gbl.user}'
         repo = git.Repo('/var/lib/git/grading.git')
         try:
             grade = repo.git.execute(['git', 'notes', '--ref=grade', 'show', tag])
+            setattr(self, f'{attr}_grade', grade)
             return grade
         except git.GitCommandError:
             return '-'

--- a/orbit/radius.py
+++ b/orbit/radius.py
@@ -472,10 +472,10 @@ class AsmtTable:
             case _:
                 return '---'
 
-    def get_grade(self):
-        if self.final is None:
+    def get_grade(self, attr):
+        if attr not in ['final', 'review1', 'review2'] or (gbl := getattr(self, attr)) is None:
             return '-'
-        tag = f'{self.final.assignment}_final_{self.final.user}'
+        tag = f'{gbl.assignment}_{attr}_{gbl.user}'
         repo = git.Repo('/var/lib/git/grading.git')
         try:
             grade = repo.git.execute(['git', 'notes', '--ref=grade', 'show', tag])
@@ -541,9 +541,9 @@ class AsmtTable:
             <th>Submission ID</th>
             <th>Score</th>
           </tr>
-          {self.gradeable_row(self.peer1 + ' Peer Review', self.review1, '-') if self.peer1 else ''}
-          {self.gradeable_row(self.peer2 + ' Peer Review', self.review2, '-') if self.peer2 else ''}
-          {self.gradeable_row('Final Submission', self.final, self.get_grade())}
+          {self.gradeable_row(self.peer1 + ' Peer Review', self.review1, self.get_grade('review1')) if self.peer1 else ''}
+          {self.gradeable_row(self.peer2 + ' Peer Review', self.review2, self.get_grade('review2')) if self.peer2 else ''}
+          {self.gradeable_row('Final Submission', self.final, self.get_grade('final'))}
           <tr>
             <th>Automated Feedback</th>
             <td colspan="3">{self.get_automated_feedback('final')}</td>

--- a/orbit/radius.py
+++ b/orbit/radius.py
@@ -464,9 +464,9 @@ class AsmtTable:
                 due_date = int(self.assignment.final_due_date)
 
         if due_date < int(datetime.now().timestamp()):
-            return gbl.status
+            return gbl.auto_feedback
 
-        match gbl.status[-1]:
+        match gbl.auto_feedback[-1]:
             case '.':
                 return 'Submission accepted'
             case '?':

--- a/orbit/warpdrive.sh
+++ b/orbit/warpdrive.sh
@@ -4,6 +4,6 @@
 
 set -e
 
-DOCKER_COMPOSE=${DOCKER_COMPOSE:-podman-compose}
+PODMAN_COMPOSE=${PODMAN_COMPOSE:-podman-compose}
 
-$DOCKER_COMPOSE exec orbit ./hyperspace.py "$@"
+$PODMAN_COMPOSE exec orbit ./hyperspace.py "$@"

--- a/script-lint.sh
+++ b/script-lint.sh
@@ -8,6 +8,7 @@ set -ex
 shellcheck script-lint.sh
 shellcheck test.sh
 shellcheck test-sub.sh
+shellcheck test-sub-check.sh
 shellcheck orbit/warpdrive.sh
 shellcheck denis/configure.sh
 shellcheck mailman/inspector.sh

--- a/script-lint.sh
+++ b/script-lint.sh
@@ -7,6 +7,7 @@ set -ex
 
 shellcheck script-lint.sh
 shellcheck test.sh
+shellcheck test-sub.sh
 shellcheck orbit/warpdrive.sh
 shellcheck denis/configure.sh
 shellcheck mailman/inspector.sh

--- a/script-lint.sh
+++ b/script-lint.sh
@@ -5,10 +5,12 @@ require shellcheck
 
 set -ex
 
+# -x needed to make shellcheck follow `source` command
 shellcheck script-lint.sh
 shellcheck -x test.sh
-shellcheck test-sub.sh
+shellcheck -x test-sub.sh
 shellcheck -x test-sub-check.sh
+shellcheck -x test-sub2.sh
 shellcheck orbit/warpdrive.sh
 shellcheck denis/configure.sh
 shellcheck mailman/inspector.sh
@@ -18,6 +20,5 @@ shellcheck git/setup-repo.sh
 shellcheck git/cgi-bin/git-receive-pack
 shellcheck git/hooks/post-update
 
-# -x needed to make shellcheck follow `source` command
 shellcheck -x backup/backup.sh
 shellcheck -x backup/restore.sh

--- a/script-lint.sh
+++ b/script-lint.sh
@@ -6,9 +6,9 @@ require shellcheck
 set -ex
 
 shellcheck script-lint.sh
-shellcheck test.sh
+shellcheck -x test.sh
 shellcheck test-sub.sh
-shellcheck test-sub-check.sh
+shellcheck -x test-sub-check.sh
 shellcheck orbit/warpdrive.sh
 shellcheck denis/configure.sh
 shellcheck mailman/inspector.sh

--- a/start.sh
+++ b/start.sh
@@ -21,6 +21,7 @@ then
 		git config --global user.name PINP
 		git config --global user.email podman@podman
 		./test-sub.sh
+		./test-sub-check.sh
 
 	fi
 else

--- a/start.sh
+++ b/start.sh
@@ -11,6 +11,18 @@ podman-compose logs -f submatrix 2>&1 | sed '/Synapse now listening on TCP port 
 if [ -f test.sh ]
 then
 	./test.sh
+	if [ -f test-sub.sh ]
+	then
+		podman-compose down
+		yes | podman volume prune
+		podman-compose up -d
+		podman-compose logs -f submatrix 2>&1 | sed '/Synapse now listening on TCP port 8008/ q'
+		./dev_sockets.sh &
+		git config --global user.name PINP
+		git config --global user.email podman@podman
+		./test-sub.sh
+
+	fi
 else
 	virtualenv .
 	pip install -r requirements.txt

--- a/start.sh
+++ b/start.sh
@@ -22,7 +22,14 @@ then
 		git config --global user.email podman@podman
 		./test-sub.sh
 		./test-sub-check.sh
+		podman-compose down
+		yes | podman volume prune
+		podman-compose up -d
 		./test-sub2.sh
+		podman-compose down
+		yes | podman volume prune
+		podman-compose up -d
+		./test-sub3.sh
 
 	fi
 else

--- a/start.sh
+++ b/start.sh
@@ -22,6 +22,7 @@ then
 		git config --global user.email podman@podman
 		./test-sub.sh
 		./test-sub-check.sh
+		./test-sub2.sh
 
 	fi
 else

--- a/test-lib
+++ b/test-lib
@@ -1,5 +1,15 @@
+# This line:
+# - aborts the script after any pipeline returns nonzero (e)
+# - shows all commands as they are run (x)
+# - sets any dereference of an unset variable to trigger an error (u)
+# - causes the return value of a pipeline to be the nonzero return value
+#   of the furthest right failing command or zero if no command failed (o pipefail)
+set -exuo pipefail
+
 PODMAN=${PODMAN:-podman}
 PODMAN_COMPOSE=${PODMAN_COMPOSE:-podman-compose}
+SCRIPT_DIR=$(dirname "$(readlink -f "$0")")
+WORKDIR=$(mktemp -d)
 
 HOSTNAME_FROM_DOTENV="$(sh -c '
 set -o allexport
@@ -26,4 +36,160 @@ CURL_OPTS=( \
 --fail \
 --no-progress-meter \
 )
+
+
+get_git_port() { ${PODMAN} port singularity_git_1 | awk -F':' '{ print $2 }' ; } ;
+
+# preconditions:
+# - SCRIPT_DIR defined (singularity repo root)
+# - WORKDIR defined (arbitrary) temp directory
+setup_submissions_and_grading_repo() {
+	pushd "$SCRIPT_DIR"
+	# nuke grading repo inside container
+	# shellcheck disable=SC2016
+	${PODMAN_COMPOSE} exec git ash -c 'cd /var/lib/git/grading.git && for t in $(git tag); do git tag -d $t; done'
+	# crete and push fresh submissions repo
+	rm -rf repos/submissions
+	git/admin.sh submissions "course submissions repository"
+	pushd repos
+	git init --bare submissions
+	echo "course submissions repository" > submissions/description
+	# create a temporary workdir to push an initial commit to the submission repo
+	git init submissions_init
+	pushd submissions_init
+	echo "# submissions" > README.md
+	git add README.md
+	git status
+	git -c user.name=singularity -c user.email=singularity@singularity commit -sm 'init submissions repo'
+	git push ../submissions master
+	popd
+	rm -rf submissions_init
+	pushd submissions
+	git push --mirror http://localhost:"$(get_git_port)"/cgi-bin/git-receive-pack/submissions
+	popd
+	popd
+	popd
+
+	pushd "$WORKDIR"
+	mkdir certs
+	pushd certs
+	${PODMAN} volume export singularity_ssl-certs > certs.tar
+	tar xf certs.tar
+	popd
+	git clone http://localhost:"$(get_git_port)"/submissions
+	popd
+}
+
+create_lighting_assignment() {
+	test -n "$1"
+	test -n "$2"
+	test -n "$3"
+	test -n "$4"
+
+	local asn="$1"
+	local i_s="$2"
+	local p_s="$3"
+	local f_s="$4"
+	set +u
+	local rub="$5"
+	set -u
+
+	RUBRIC=
+	if [ -n "$rub" ]
+	then
+		RUBRIC="-r $rub"
+	fi
+
+	pushd "$SCRIPT_DIR"
+	# create or recreate setup assignment
+	if denis/configure.sh dump | grep -q "^$asn:"; then
+		denis/configure.sh remove -a "$asn"
+	fi
+	denis/configure.sh create -a "$asn" -i "$(date -d "$i_s secs" +%s)" -p "$(date -d "$p_s secs" +%s)" -f "$(date -d "$f_s secs" +%s)" ${RUBRIC}
+	denis/configure.sh reload
+	popd
+}
+
+# preconditions:
+# - called after setup_submissions_and_grading_repo
+setup_submissions_for() {
+	test -n "$1"
+	local user="$1"
+
+	pushd "$SCRIPT_DIR"
+	orbit/warpdrive.sh -u "$user" -p builder -n || orbit/warpdrive.sh -u "$user" -p builder -m
+	popd
+
+	pushd "$WORKDIR"/submissions
+	git config user.name "$user"
+	git config user.email "$user"@localhost.localdomain
+	git config sendemail.smtpUser "$user"
+	git config sendemail.smtpPass builder
+	git config sendemail.smtpserver localhost.localdomain
+	git config sendemail.smtpserverport 465
+	git config sendemail.smtpencryption ssl
+	popd
+}
+
+# preconditions:
+# - no non-tracked files in submissions repo
+# - called after setup_submissions_for
+enter_and_checkout() {
+	test -n "$1"
+	local branch="$1"
+
+	pushd "$WORKDIR"/submissions
+	git checkout --orphan "$1"
+	if [ -n "$(ls)" ]
+	then
+		git rm -rf ./*
+	fi
+}
+
+# preconditions:
+# - called after a call to enter_and_checkout
+exit_after_sending() {
+	test -n "$1"
+	local asn="$1"
+
+	git send-email \
+		--confirm=never \
+		--smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem \
+		--to "$asn"@localhost.localdomain \
+		./*.patch
+	rm ./*.patch
+	popd
+	sleep 1
+}
+
+# preconditions:
+# - called after a call to enter_and_checkout
+write_commit_to() {
+	test -n "$1" && test -n "$2"
+	local content="$1"
+	local file="$2"
+	set +u # necessary since $3 is unbound in 2 arg case
+	local opt="$3"
+	set -x
+
+	mkdir -p $(dirname "$file")
+
+	if [ "$opt" == "append" ]; then
+		echo "$content" >> "$file"
+	else
+		echo "$content" > "$file"
+	fi
+
+	git add "$file"
+	git commit -sm "add $content to $file"
+}
+
+# preconditions:
+# - called after a call to write_commit_to
+fixup_cover() {
+	test -n "$1"
+	sed -i "s/\*\*\* SUBJECT HERE \*\*\*/$1/g" *0000-cover-letter.patch
+	sed -i "s/\*\*\* BLURB HERE \*\*\*/$1/g" *0000-cover-letter.patch
+	sed -i "\$a\\Signed-off-by: $(git config user.name) <$(git config user.email)>" *0000-cover-letter.patch
+}
 

--- a/test-lib
+++ b/test-lib
@@ -1,0 +1,29 @@
+PODMAN=${PODMAN:-podman}
+PODMAN_COMPOSE=${PODMAN_COMPOSE:-podman-compose}
+
+HOSTNAME_FROM_DOTENV="$(sh -c '
+set -o allexport
+. ./.env
+exec jq -r -n "env.SINGULARITY_HOSTNAME"
+')"
+
+SINGULARITY_HOSTNAME=${SINGULARITY_HOSTNAME:-"${HOSTNAME_FROM_DOTENV}"}
+
+setup_testdir() {
+	# Create test dir if it does not exist yet
+	mkdir -p test
+
+	# Reset the test directory
+	rm -f test/*
+
+	# put the cert in there
+	${PODMAN} cp singularity_nginx_1:/etc/ssl/nginx/fullchain.pem test/ca_cert.pem
+}
+
+CURL_OPTS=( \
+--verbose \
+--cacert test/ca_cert.pem \
+--fail \
+--no-progress-meter \
+)
+

--- a/test-sub-check.sh
+++ b/test-sub-check.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+CURL_OPTS=( \
+--verbose \
+--cacert test/ca_cert.pem \
+--fail \
+--no-progress-meter \
+)
+
+set -exuo pipefail
+
+HOSTNAME_FROM_DOTENV="$(sh -c '
+set -o allexport
+. ./.env
+exec jq -r -n "env.SINGULARITY_HOSTNAME"
+')"
+
+DOCKER=${DOCKER:-podman}
+
+SINGULARITY_HOSTNAME=${SINGULARITY_HOSTNAME:-"${HOSTNAME_FROM_DOTENV}"}
+
+# Create test dir if it does not exist yet
+mkdir -p test
+
+# Reset the test directory
+rm -f test/*
+
+${DOCKER} cp singularity_nginx_1:/etc/ssl/nginx/fullchain.pem test/ca_cert.pem
+
+# login as bob
+curl --url "https://$SINGULARITY_HOSTNAME/login" \
+  --unix-socket ./socks/https.sock \
+  "${CURL_OPTS[@]}" \
+  -c test/cookies \
+  --data "username=bob&password=builder" \
+  | tee test/login_success \
+  | grep "msg = bob authenticated by password"
+
+
+# check for setup assignment and save dashboard
+curl --url "https://$SINGULARITY_HOSTNAME/dashboard" \
+  --unix-socket ./socks/https.sock \
+  -b test/cookies \
+  "${CURL_OPTS[@]}" \
+  | tee test/dashboard \
+  | grep "setup"
+
+grep "Total Score: 64.9" test/dashboard
+
+grep "missing cover letter and first patch failed to apply!" test/dashboard
+
+grep "bib Peer Review" test/dashboard
+
+grep "bab Peer Review" test/dashboard
+
+grep "patchset applies." test/dashboard
+
+grep "Good effort but try harder next time." test/dashboard
+
+# login as bab
+curl --url "https://$SINGULARITY_HOSTNAME/login" \
+  --unix-socket ./socks/https.sock \
+  "${CURL_OPTS[@]}" \
+  -c test/cookies_bab \
+  --data "username=bab&password=builder" \
+  | tee test/login_success_bab \
+  | grep "msg = bab authenticated by password"
+
+
+# check for setup assignment and save dashboard
+curl --url "https://$SINGULARITY_HOSTNAME/dashboard" \
+  --unix-socket ./socks/https.sock \
+  -b test/cookies_bab \
+  "${CURL_OPTS[@]}" \
+  | tee test/dashboard_bab \
+  | grep "setup"
+
+grep "Total Score: 0.0" test/dashboard_bab
+
+grep "bib Peer Review" test/dashboard_bab
+
+grep "bob Peer Review" test/dashboard_bab
+
+grep "patchset applies." test/dashboard_bab
+
+grep "illegal patch 1: permission denied for path work!" test/dashboard_bab
+
+grep 'Please review git' test/dashboard_bab
+
+# login as bib
+curl --url "https://$SINGULARITY_HOSTNAME/login" \
+  --unix-socket ./socks/https.sock \
+  "${CURL_OPTS[@]}" \
+  -c test/cookies_bib \
+  --data "username=bib&password=builder" \
+  | tee test/login_success_bib \
+  | grep "msg = bib authenticated by password"
+
+
+# check for setup assignment and save dashboard
+curl --url "https://$SINGULARITY_HOSTNAME/dashboard" \
+  --unix-socket ./socks/https.sock \
+  -b test/cookies_bib \
+  "${CURL_OPTS[@]}" \
+  | tee test/dashboard_bib \
+  | grep "setup"
+
+grep "Total Score: 80.0" test/dashboard_bib
+
+grep "bob Peer Review" test/dashboard_bib
+
+grep "bab Peer Review" test/dashboard_bib
+
+grep "patchset applies." test/dashboard_bib
+
+grep 'Perfect. But no peer review!' test/dashboard_bib
+
+echo "ALL SUBMISSION TESTS PASS"

--- a/test-sub-check.sh
+++ b/test-sub-check.sh
@@ -15,7 +15,7 @@ set -o allexport
 exec jq -r -n "env.SINGULARITY_HOSTNAME"
 ')"
 
-DOCKER=${DOCKER:-podman}
+PODMAN=${PODMAN:-podman}
 
 SINGULARITY_HOSTNAME=${SINGULARITY_HOSTNAME:-"${HOSTNAME_FROM_DOTENV}"}
 
@@ -25,7 +25,7 @@ mkdir -p test
 # Reset the test directory
 rm -f test/*
 
-${DOCKER} cp singularity_nginx_1:/etc/ssl/nginx/fullchain.pem test/ca_cert.pem
+${PODMAN} cp singularity_nginx_1:/etc/ssl/nginx/fullchain.pem test/ca_cert.pem
 
 # login as bob
 curl --url "https://$SINGULARITY_HOSTNAME/login" \

--- a/test-sub-check.sh
+++ b/test-sub-check.sh
@@ -1,7 +1,5 @@
 #!/usr/bin/env bash
 
-set -exuo pipefail
-
 source test-lib
 
 setup_testdir

--- a/test-sub-check.sh
+++ b/test-sub-check.sh
@@ -1,31 +1,10 @@
 #!/usr/bin/env bash
 
-CURL_OPTS=( \
---verbose \
---cacert test/ca_cert.pem \
---fail \
---no-progress-meter \
-)
-
 set -exuo pipefail
 
-HOSTNAME_FROM_DOTENV="$(sh -c '
-set -o allexport
-. ./.env
-exec jq -r -n "env.SINGULARITY_HOSTNAME"
-')"
+source test-lib
 
-PODMAN=${PODMAN:-podman}
-
-SINGULARITY_HOSTNAME=${SINGULARITY_HOSTNAME:-"${HOSTNAME_FROM_DOTENV}"}
-
-# Create test dir if it does not exist yet
-mkdir -p test
-
-# Reset the test directory
-rm -f test/*
-
-${PODMAN} cp singularity_nginx_1:/etc/ssl/nginx/fullchain.pem test/ca_cert.pem
+setup_testdir
 
 # login as bob
 curl --url "https://$SINGULARITY_HOSTNAME/login" \

--- a/test-sub.sh
+++ b/test-sub.sh
@@ -1,283 +1,90 @@
 #!/bin/bash
 
-set -exuo pipefail
+# assumes singularity is running when invoked
+# script is written to be as idempotent as posible
 
-SCRIPT_DIR=$(dirname "$0")
+source test-lib
 
-cd "$SCRIPT_DIR"
-
-get_git_port() { podman port singularity_git_1 | awk -F':' '{ print $2 }' ; } ;
-
-# nuke grading repo inside container
-# shellcheck disable=SC2016
-podman-compose exec git ash -c 'cd /var/lib/git/grading.git && for t in $(git tag); do git tag -d $t; done'
-
-# setup submissions repo
-rm -rf repos/submissions
-git/admin.sh submissions "course submissions repository"
-pushd repos
-git init --bare submissions
-echo "course submissions repository" > submissions/description
-git init submissions_init
-pushd submissions_init
-echo "# submissions" > README.md
-git add README.md
-git -c user.name=singularity -c user.email=singularity@singularity commit -m 'init submissions repo'
-git push ../submissions master
-popd
-rm -rf submissions_init
-pushd submissions
-git push --mirror http://localhost:"$(get_git_port)"/cgi-bin/git-receive-pack/submissions
-popd
-popd
-
-# create bob,bib,bab users or change their passwords to builder
-orbit/warpdrive.sh -u bob -p builder -n || orbit/warpdrive.sh -u bob -p builder -m
-orbit/warpdrive.sh -u bib -p builder -n || orbit/warpdrive.sh -u bob -p builder -m
-orbit/warpdrive.sh -u bab -p builder -n || orbit/warpdrive.sh -u bob -p builder -m
-
-WORKDIR=$(mktemp -d)
+setup_submissions_and_grading_repo
 
 cat << EOF > "$WORKDIR"/setup_rubric
 [{('--- /dev/null', '+++ b/bob/setup/work'): 0},
 {('--- a/bob/setup/work', '+++ b/bob/setup/work'): 0}]
 EOF
 
-# create or recreate setup assignment
-if denis/configure.sh dump | grep -q "^setup:"; then
-	denis/configure.sh remove -a setup
-fi
-denis/configure.sh create -a setup -i "$(date -d "15 secs" +%s)" -p "$(date -d "25 secs" +%s)" -f "$(date -d "30 secs" +%s)" -r "$WORKDIR"/setup_rubric
-denis/configure.sh reload
-
-# setup assignment environment
-pushd "$WORKDIR"
-
-mkdir certs
-pushd certs
-podman volume export singularity_ssl-certs > certs.tar
-tar xf certs.tar
-popd
-git clone http://localhost:"$(get_git_port)"/submissions
-
-# bob env setup
-
-pushd submissions
-git config user.name bob
-git config user.email bob@localhost.localdomain
-git config sendemail.smtpUser bob
-git config sendemail.smtpPass builder
-git config sendemail.smtpserver localhost.localdomain
-git config sendemail.smtpserverport 465
-git config sendemail.smtpencryption ssl
-popd
+create_lighting_assignment setup 15 25 30 "$WORKDIR"/setup_rubric
 
 # setup_intial_bob patchsets
+setup_submissions_for bob
 
 # good patchset
-pushd submissions
-git checkout --orphan setup_initial_bob_good
-git rm -rf ./*
-mkdir -p bob/setup
-
-echo "abc" > bob/setup/work
-git add bob/setup/work
-git commit -sm 'add abc to work'
-
-echo "def" >> bob/setup/work
-git add bob/setup/work
-git commit -sm 'add def to work'
-
+enter_and_checkout setup_initial_bob_good
+write_commit_to "abc" bob/setup/work
+write_commit_to "def" bob/setup/work "append"
 git format-patch --rfc --cover-letter -v1 -2
-sed -i 's/\*\*\* SUBJECT HERE \*\*\*/Good patchset/g' v1-0000-cover-letter.patch
-sed -i 's/\*\*\* BLURB HERE \*\*\*/Good patchset/g' v1-0000-cover-letter.patch
-
-git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
-rm ./*.patch
-popd
-sleep 1
+fixup_cover "Good patchset"
+exit_after_sending setup
 
 # corrupt patchset
-pushd submissions
-git checkout --orphan setup_initial_bob_corrupt
-git rm -rf ./*
-mkdir -p bob/setup
-
-echo "abc" > bob/setup/work
-git add bob/setup/work
-git commit -sm 'add abc to work'
-
-echo "def" >> bob/setup/work
-git add bob/setup/work
-git commit -sm 'add def to work'
-
-echo "ghi" >> bob/setup/work
-git add bob/setup/work
-git commit -sm 'add ghi to work'
-
+enter_and_checkout setup_initial_bob_corrupt
+write_commit_to "abc" bob/setup/work
+write_commit_to "def" bob/setup/work "append"
+write_commit_to "ghi" bob/setup/work "append"
 git format-patch --rfc --cover-letter -v1 -3
 rm v1-0002-*.patch
-
-sed -i 's/\*\*\* SUBJECT HERE \*\*\*/Corrupt patchset/g' v1-0000-cover-letter.patch
-sed -i 's/\*\*\* BLURB HERE \*\*\*/Corrupt patchset/g' v1-0000-cover-letter.patch
-
-git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
-rm ./*.patch
-popd
-sleep 1
+fixup_cover "Corrupt patchset"
+exit_after_sending setup
 
 # patchset with whitespace errors
-pushd submissions
-git checkout --orphan setup_initial_bob_whitespace
-git rm -rf ./*
-mkdir -p bob/setup
-
-echo "abc" > bob/setup/work
-git add bob/setup/work
-git commit -sm 'add abc to work'
-
-echo "def	" >> bob/setup/work
-git add bob/setup/work
-git commit -sm 'add def to work'
-
+enter_and_checkout setup_initial_bob_whitespace
+write_commit_to "abc" bob/setup/work
+write_commit_to "def	" bob/setup/work "append"
 git format-patch --rfc --cover-letter -v1 -2
-sed -i 's/\*\*\* SUBJECT HERE \*\*\*/Patchset with whitespace errors/g' v1-0000-cover-letter.patch
-sed -i 's/\*\*\* BLURB HERE \*\*\*/Patchset with whitespace errors/g' v1-0000-cover-letter.patch
-
-git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
-rm ./*.patch
-popd
-sleep 1
+fixup_cover "Patchset with whitespace errors"
+exit_after_sending setup
 
 # patchset with no cover letter
-pushd submissions
-git checkout --orphan setup_initial_bob_nocover
-git rm -rf ./*
-mkdir -p bob/setup
-
-echo "abc" > bob/setup/work
-git add bob/setup/work
-git commit -sm 'add abc to work'
-
-echo "def" >> bob/setup/work
-git add bob/setup/work
-git commit -sm 'add def to work'
-
+enter_and_checkout setup_initial_bob_nocover
+write_commit_to "abc" bob/setup/work
+write_commit_to "def" bob/setup/work "append"
 git format-patch --rfc -v1 -2
-
-git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
-rm ./*.patch
-popd
-sleep 1
+exit_after_sending setup
 
 # patchset with no cover letter and corrupt first patch
-pushd submissions
-git checkout --orphan setup_initial_bob_nocover-corrupt
-git rm -rf ./*
-mkdir -p bob/setup
-
-echo "abc" > bob/setup/work
-git add bob/setup/work
-git commit -sm 'add abc to work'
-
-echo "def" >> bob/setup/work
-git add bob/setup/work
-git commit -sm 'add def to work'
-
-echo "ghi" >> bob/setup/work
-git add bob/setup/work
-git commit -sm 'add ghi to work'
-
+enter_and_checkout setup_initial_bob_nocover-corrupt
+write_commit_to "abc" bob/setup/work
+write_commit_to "def" bob/setup/work "append"
+write_commit_to "ghi" bob/setup/work "append"
 git format-patch --rfc -v1 -2
-
-git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
-rm ./*.patch
-popd
-
-# end of setup_initial_bob patchsets
-
-# bab env setup
-
-pushd submissions
-git config user.name bab
-git config user.email bab@localhost.localdomain
-git config sendemail.smtpUser bab
-git config sendemail.smtpPass builder
-git config sendemail.smtpserver localhost.localdomain
-git config sendemail.smtpserverport 465
-git config sendemail.smtpencryption ssl
-popd
+exit_after_sending setup
 
 # setup_initial_bab submissions
+setup_submissions_for bab
 
 # bab good patchset
-pushd submissions
-git checkout --orphan setup_initial_bab_good
-git rm -rf ./*
-mkdir -p bab/setup
-
-echo "abc" > bab/setup/work
-git add bab/setup/work
-git commit -sm 'add abc to work'
-
-echo "def" >> bab/setup/work
-git add bab/setup/work
-git commit -sm 'add def to work'
-
+enter_and_checkout setup_initial_bab_good
+write_commit_to "abc" bab/setup/work
+write_commit_to "def" bab/setup/work "append"
 git format-patch --rfc --cover-letter -v1 -2
-sed -i 's/\*\*\* SUBJECT HERE \*\*\*/bab: Good patchset/g' v1-0000-cover-letter.patch
-sed -i 's/\*\*\* BLURB HERE \*\*\*/bab: Good patchset/g' v1-0000-cover-letter.patch
+fixup_cover "Good patchset"
+exit_after_sending setup
 
-git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
-rm -rf ./*.patch
-popd
-
-# end of bab initial submission
-
-# bib env setup
-pushd submissions
-git config user.name bib
-git config user.email bib@localhost.localdomain
-git config sendemail.smtpUser bib
-git config sendemail.smtpPass builder
-git config sendemail.smtpserver localhost.localdomain
-git config sendemail.smtpserverport 465
-git config sendemail.smtpencryption ssl
-popd
-
-# bib initial submissions
+# setup_initial_bib submissions
+setup_submissions_for bib
 
 # bib good patchset
-pushd submissions
-git checkout --orphan setup_initial_bib_good
-git rm -rf ./*
-mkdir -p bib/setup
-
-echo "abc" > bib/setup/work
-git add bib/setup/work
-git commit -sm 'add abc to work'
-
-echo "def" >> bib/setup/work
-git add bib/setup/work
-git commit -sm 'add def to work'
-
+enter_and_checkout setup_initial_bib_good
+write_commit_to "abc" bib/setup/work
+write_commit_to "def" bib/setup/work "append"
 git format-patch --rfc --cover-letter -v1 -2
-sed -i 's/\*\*\* SUBJECT HERE \*\*\*/bib: Good patchset/g' v1-0000-cover-letter.patch
-sed -i 's/\*\*\* BLURB HERE \*\*\*/bib: Good patchset/g' v1-0000-cover-letter.patch
-
-git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
-rm ./*.patch
-popd
-sleep 1
-
-# end of bib initial submission
+fixup_cover "Good patchset"
+exit_after_sending setup
 
 # investigate grading repo
+pushd "$WORKDIR"
 git clone http://localhost:"$(get_git_port)"/grading.git
 pushd grading
 git fetch --tag
-git tag
-
 
 STATUSES=(
 'patchset applies.'
@@ -300,36 +107,17 @@ for t in $(git tag); do
 	fi
 	i=$((i+1))
 done
-
 popd
 
-echo "wait for initial submission deadline (10 secs)"
-sleep 10
+echo "wait for initial submission deadline (5 secs)"
+sleep 5
 
-# bob env setup
-
-pushd submissions
-git config user.name bob
-git config user.email bob@localhost.localdomain
-git config sendemail.smtpUser bob
-git config sendemail.smtpPass builder
-git config sendemail.smtpserver localhost.localdomain
-git config sendemail.smtpserverport 465
-git config sendemail.smtpencryption ssl
-popd
-
+setup_submissions_for bob
 
 # setup bob peer review
-pushd submissions
-git checkout --orphan setup_reviews_bob
-git rm -rf ./*
-# mkdir -p bob/setup (must be able to omit if missing)
-echo ORPHAN > ORPHAN
-git add ORPHAN
-git commit -m 'orphan base'
+enter_and_checkout setup_reviews_bob
 
 # submit peer review 1
-
 cat <<PEER_REVIEW1 > review1
 Subject: setup review 1 for bab
 In-Reply-To: <${PEER1_ID::-1}1@localhost.localdomain>
@@ -338,14 +126,10 @@ Looks good to me
 
 Acked-by: bob <bob@localhost.localdomain>
 PEER_REVIEW1
-
 git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to bab@localhost.localdomain review1
 rm review1
 
-# end peer review 1
-
 # submit peer review 2
-
 cat <<PEER_REVIEW2 > review2
 Subject: setup review 2 for bib
 In-Reply-To: <${PEER2_ID::-1}2@localhost.localdomain>
@@ -354,131 +138,39 @@ Looks good to me
 
 Acked-by: bob <bob@localhost.localdomain>
 PEER_REVIEW2
-
 git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to bib@localhost.localdomain review2
 rm review2
 
-# end peer review 2
-
+popd
+sleep 1
 # end bob peer review
-popd
-sleep 1
 
-# bob env setup
-
-pushd submissions
-git config user.name bob
-git config user.email bob@localhost.localdomain
-git config sendemail.smtpUser bob
-git config sendemail.smtpPass builder
-git config sendemail.smtpserver localhost.localdomain
-git config sendemail.smtpserverport 465
-git config sendemail.smtpencryption ssl
-popd
-
-# bob make final submission
-
-# good final patchset
-pushd submissions
-git checkout --orphan setup_final_bob_good
-git rm -rf ./*
-mkdir -p bob/setup
-
-echo "abc" > bob/setup/work
-git add bob/setup/work
-git commit -sm 'add abc to work'
-
-echo "def" >> bob/setup/work
-git add bob/setup/work
-git commit -sm 'add def to work'
-
+# setup_final_bob good patchset
+setup_submissions_for bob
+enter_and_checkout setup_final_bob_good
+write_commit_to "abc" bob/setup/work
+write_commit_to "def" bob/setup/work "append"
 git format-patch --cover-letter -v2 -2
-sed -i 's/\*\*\* SUBJECT HERE \*\*\*/Good patchset final/g' v2-0000-cover-letter.patch
-sed -i 's/\*\*\* BLURB HERE \*\*\*/Good patchset final/g' v2-0000-cover-letter.patch
+fixup_cover "Good final patchset"
+exit_after_sending setup
 
-git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
-rm ./*.patch
-popd
-sleep 1
-
-# end bob final submission
-
-# bib env setup
-
-pushd submissions
-git config user.name bib
-git config user.email bib@localhost.localdomain
-git config sendemail.smtpUser bib
-git config sendemail.smtpPass builder
-git config sendemail.smtpserver localhost.localdomain
-git config sendemail.smtpserverport 465
-git config sendemail.smtpencryption ssl
-popd
-
-# bib final submission labeled RFC
-pushd submissions
-git checkout --orphan setup_final_bib_rfc
-git rm -rf ./*
-mkdir -p bib/setup
-
-echo "abc" > bib/setup/work
-git add bib/setup/work
-git commit -sm 'add abc to work'
-
-echo "def" >> bib/setup/work
-git add bib/setup/work
-git commit -sm 'add def to work'
-
+# setup_final_bib final submission incorrectly labeled RFC
+setup_submissions_for bib
+enter_and_checkout setup_final_bib_rfc
+write_commit_to "abc" bib/setup/work
+write_commit_to "def" bib/setup/work "append"
 git format-patch --rfc --cover-letter -v1 -2
-sed -i 's/\*\*\* SUBJECT HERE \*\*\*/bib: RFC patchset/g' v1-0000-cover-letter.patch
-sed -i 's/\*\*\* BLURB HERE \*\*\*/bib: RFC patchset/g' v1-0000-cover-letter.patch
+fixup_cover "RFC tagged final patchset"
+exit_after_sending setup
 
-git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
-rm ./*.patch
-popd
-sleep 1
-
-# end of bib final submission labeled RFC
-
-
-# bab env setup
-
-pushd submissions
-git config user.name bab
-git config user.email bab@localhost.localdomain
-git config sendemail.smtpUser bab
-git config sendemail.smtpPass builder
-git config sendemail.smtpserver localhost.localdomain
-git config sendemail.smtpserverport 465
-git config sendemail.smtpencryption ssl
-popd
-
-
-# bab final submission in wrong directory
-pushd submissions
-git checkout --orphan setup_final_bab_illegal
-git rm -rf ./*
-mkdir -p bib/setup
-
-echo "abc" > work
-git add work
-git commit -sm 'add abc to work'
-
-echo "def" >> work
-git add work
-git commit -sm 'add def to work'
-
+# setup_final_bab submission in wrong directory
+setup_submissions_for bab
+enter_and_checkout setup_final_bab_illegal
+write_commit_to "abc" work
+write_commit_to "def" work "append"
 git format-patch --rfc --cover-letter -v1 -2
-sed -i 's/\*\*\* SUBJECT HERE \*\*\*/bab: Illegal patchset/g' v1-0000-cover-letter.patch
-sed -i 's/\*\*\* BLURB HERE \*\*\*/bab: Illegal patchset/g' v1-0000-cover-letter.patch
-
-git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
-rm ./*.patch
-popd
-sleep 1
-
-# end of bab final submission in wrong directory
-
+fixup_cover "Illegal patchset"
+exit_after_sending setup
 
 echo "wait for final submission deadline (10 secs)"
 sleep 10
@@ -488,14 +180,17 @@ git fetch --tag
 sleep 2
 git fetch -f origin refs/notes/*:refs/notes/*
 git remote set-url --push origin http://localhost:"$(get_git_port)"/cgi-bin/git-receive-pack/grading.git
+
 git notes --ref=grade add setup_final_bob -m '66'
 git notes --ref=grade add setup_review1_bob -m '22'
 git notes --ref=grade add setup_review2_bob -m '99'
 git notes --ref=feedback add setup_final_bob -m 'Good effort but try harder next time.'
 
+# automatic 0 for peer reviews
 git notes --ref=grade add setup_final_bib -m '100'
 git notes --ref=feedback add setup_final_bib -m 'Perfect. But no peer review!'
 
+# automatic 0 for peer reviews and final submission
 git notes --ref=feedback add setup_final_bab -m 'Please review git'
 
 git push origin refs/notes/*:refs/notes/*

--- a/test-sub.sh
+++ b/test-sub.sh
@@ -1,0 +1,503 @@
+#!/bin/bash
+
+set -exuo pipefail
+
+SCRIPT_DIR=$(dirname "$0")
+
+cd "$SCRIPT_DIR"
+
+get_git_port() { podman port singularity_git_1 | awk -F':' '{ print $2 }' ; } ;
+
+# nuke grading repo inside container
+# shellcheck disable=SC2016
+podman-compose exec git ash -c 'cd /var/lib/git/grading.git && for t in $(git tag); do git tag -d $t; done'
+
+# setup submissions repo
+rm -rf repos/submissions
+git/admin.sh submissions "course submissions repository"
+pushd repos
+git init --bare submissions
+echo "course submissions repository" > submissions/description
+git init submissions_init
+pushd submissions_init
+echo "# submissions" > README.md
+git add README.md
+git -c user.name=singularity -c user.email=singularity@singularity commit -m 'init submissions repo'
+git push ../submissions master
+popd
+rm -rf submissions_init
+pushd submissions
+git push --mirror http://localhost:"$(get_git_port)"/cgi-bin/git-receive-pack/submissions
+popd
+popd
+
+# create bob,bib,bab users or change their passwords to builder
+orbit/warpdrive.sh -u bob -p builder -n || orbit/warpdrive.sh -u bob -p builder -m
+orbit/warpdrive.sh -u bib -p builder -n || orbit/warpdrive.sh -u bob -p builder -m
+orbit/warpdrive.sh -u bab -p builder -n || orbit/warpdrive.sh -u bob -p builder -m
+
+WORKDIR=$(mktemp -d)
+
+cat << EOF > "$WORKDIR"/setup_rubric
+[{('--- /dev/null', '+++ b/bob/setup/work'): 0},
+{('--- a/bob/setup/work', '+++ b/bob/setup/work'): 0}]
+EOF
+
+# create or recreate setup assignment
+if denis/configure.sh dump | grep -q "^setup:"; then
+	denis/configure.sh remove -a setup
+fi
+denis/configure.sh create -a setup -i "$(date -d "15 secs" +%s)" -p "$(date -d "25 secs" +%s)" -f "$(date -d "30 secs" +%s)" -r "$WORKDIR"/setup_rubric
+denis/configure.sh reload
+
+# setup assignment environment
+pushd "$WORKDIR"
+
+mkdir certs
+pushd certs
+podman volume export singularity_ssl-certs > certs.tar
+tar xf certs.tar
+popd
+git clone http://localhost:"$(get_git_port)"/submissions
+
+# bob env setup
+
+pushd submissions
+git config user.name bob
+git config user.email bob@localhost.localdomain
+git config sendemail.smtpUser bob
+git config sendemail.smtpPass builder
+git config sendemail.smtpserver localhost.localdomain
+git config sendemail.smtpserverport 465
+git config sendemail.smtpencryption ssl
+popd
+
+# setup_intial_bob patchsets
+
+# good patchset
+pushd submissions
+git checkout --orphan setup_initial_bob_good
+git rm -rf ./*
+mkdir -p bob/setup
+
+echo "abc" > bob/setup/work
+git add bob/setup/work
+git commit -sm 'add abc to work'
+
+echo "def" >> bob/setup/work
+git add bob/setup/work
+git commit -sm 'add def to work'
+
+git format-patch --rfc --cover-letter -v1 -2
+sed -i 's/\*\*\* SUBJECT HERE \*\*\*/Good patchset/g' v1-0000-cover-letter.patch
+sed -i 's/\*\*\* BLURB HERE \*\*\*/Good patchset/g' v1-0000-cover-letter.patch
+
+git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
+rm ./*.patch
+popd
+sleep 1
+
+# corrupt patchset
+pushd submissions
+git checkout --orphan setup_initial_bob_corrupt
+git rm -rf ./*
+mkdir -p bob/setup
+
+echo "abc" > bob/setup/work
+git add bob/setup/work
+git commit -sm 'add abc to work'
+
+echo "def" >> bob/setup/work
+git add bob/setup/work
+git commit -sm 'add def to work'
+
+echo "ghi" >> bob/setup/work
+git add bob/setup/work
+git commit -sm 'add ghi to work'
+
+git format-patch --rfc --cover-letter -v1 -3
+rm v1-0002-*.patch
+
+sed -i 's/\*\*\* SUBJECT HERE \*\*\*/Corrupt patchset/g' v1-0000-cover-letter.patch
+sed -i 's/\*\*\* BLURB HERE \*\*\*/Corrupt patchset/g' v1-0000-cover-letter.patch
+
+git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
+rm ./*.patch
+popd
+sleep 1
+
+# patchset with whitespace errors
+pushd submissions
+git checkout --orphan setup_initial_bob_whitespace
+git rm -rf ./*
+mkdir -p bob/setup
+
+echo "abc" > bob/setup/work
+git add bob/setup/work
+git commit -sm 'add abc to work'
+
+echo "def	" >> bob/setup/work
+git add bob/setup/work
+git commit -sm 'add def to work'
+
+git format-patch --rfc --cover-letter -v1 -2
+sed -i 's/\*\*\* SUBJECT HERE \*\*\*/Patchset with whitespace errors/g' v1-0000-cover-letter.patch
+sed -i 's/\*\*\* BLURB HERE \*\*\*/Patchset with whitespace errors/g' v1-0000-cover-letter.patch
+
+git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
+rm ./*.patch
+popd
+sleep 1
+
+# patchset with no cover letter
+pushd submissions
+git checkout --orphan setup_initial_bob_nocover
+git rm -rf ./*
+mkdir -p bob/setup
+
+echo "abc" > bob/setup/work
+git add bob/setup/work
+git commit -sm 'add abc to work'
+
+echo "def" >> bob/setup/work
+git add bob/setup/work
+git commit -sm 'add def to work'
+
+git format-patch --rfc -v1 -2
+
+git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
+rm ./*.patch
+popd
+sleep 1
+
+# patchset with no cover letter and corrupt first patch
+pushd submissions
+git checkout --orphan setup_initial_bob_nocover-corrupt
+git rm -rf ./*
+mkdir -p bob/setup
+
+echo "abc" > bob/setup/work
+git add bob/setup/work
+git commit -sm 'add abc to work'
+
+echo "def" >> bob/setup/work
+git add bob/setup/work
+git commit -sm 'add def to work'
+
+echo "ghi" >> bob/setup/work
+git add bob/setup/work
+git commit -sm 'add ghi to work'
+
+git format-patch --rfc -v1 -2
+
+git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
+rm ./*.patch
+popd
+
+# end of setup_initial_bob patchsets
+
+# bab env setup
+
+pushd submissions
+git config user.name bab
+git config user.email bab@localhost.localdomain
+git config sendemail.smtpUser bab
+git config sendemail.smtpPass builder
+git config sendemail.smtpserver localhost.localdomain
+git config sendemail.smtpserverport 465
+git config sendemail.smtpencryption ssl
+popd
+
+# setup_initial_bab submissions
+
+# bab good patchset
+pushd submissions
+git checkout --orphan setup_initial_bab_good
+git rm -rf ./*
+mkdir -p bab/setup
+
+echo "abc" > bab/setup/work
+git add bab/setup/work
+git commit -sm 'add abc to work'
+
+echo "def" >> bab/setup/work
+git add bab/setup/work
+git commit -sm 'add def to work'
+
+git format-patch --rfc --cover-letter -v1 -2
+sed -i 's/\*\*\* SUBJECT HERE \*\*\*/bab: Good patchset/g' v1-0000-cover-letter.patch
+sed -i 's/\*\*\* BLURB HERE \*\*\*/bab: Good patchset/g' v1-0000-cover-letter.patch
+
+git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
+rm -rf ./*.patch
+popd
+
+# end of bab initial submission
+
+# bib env setup
+pushd submissions
+git config user.name bib
+git config user.email bib@localhost.localdomain
+git config sendemail.smtpUser bib
+git config sendemail.smtpPass builder
+git config sendemail.smtpserver localhost.localdomain
+git config sendemail.smtpserverport 465
+git config sendemail.smtpencryption ssl
+popd
+
+# bib initial submissions
+
+# bib good patchset
+pushd submissions
+git checkout --orphan setup_initial_bib_good
+git rm -rf ./*
+mkdir -p bib/setup
+
+echo "abc" > bib/setup/work
+git add bib/setup/work
+git commit -sm 'add abc to work'
+
+echo "def" >> bib/setup/work
+git add bib/setup/work
+git commit -sm 'add def to work'
+
+git format-patch --rfc --cover-letter -v1 -2
+sed -i 's/\*\*\* SUBJECT HERE \*\*\*/bib: Good patchset/g' v1-0000-cover-letter.patch
+sed -i 's/\*\*\* BLURB HERE \*\*\*/bib: Good patchset/g' v1-0000-cover-letter.patch
+
+git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
+rm ./*.patch
+popd
+sleep 1
+
+# end of bib initial submission
+
+# investigate grading repo
+git clone http://localhost:"$(get_git_port)"/grading.git
+pushd grading
+git fetch --tag
+git tag
+
+
+STATUSES=(
+'patchset applies.'
+'patch 2 failed to apply!'
+'whitespace error patch 2?'
+'missing cover letter!'
+'missing cover letter and first patch failed to apply!'
+'patchset applies.'
+'patchset applies.')
+
+# submitted patchses should have statuses in this order
+# assumption: first ID tag is first patch submitted by this script and IDs increase monotonically
+i=0
+for t in $(git tag); do
+	git show -s --oneline "$t" | grep -q "${STATUSES[$i]}"
+	if [[ $i == 5 ]]; then
+		PEER1_ID=$t
+	elif [[ $i == 6 ]]; then
+		PEER2_ID=$t
+	fi
+	i=$((i+1))
+done
+
+popd
+
+echo "wait for initial submission deadline (10 secs)"
+sleep 10
+
+# bob env setup
+
+pushd submissions
+git config user.name bob
+git config user.email bob@localhost.localdomain
+git config sendemail.smtpUser bob
+git config sendemail.smtpPass builder
+git config sendemail.smtpserver localhost.localdomain
+git config sendemail.smtpserverport 465
+git config sendemail.smtpencryption ssl
+popd
+
+
+# setup bob peer review
+pushd submissions
+git checkout --orphan setup_reviews_bob
+git rm -rf ./*
+# mkdir -p bob/setup (must be able to omit if missing)
+echo ORPHAN > ORPHAN
+git add ORPHAN
+git commit -m 'orphan base'
+
+# submit peer review 1
+
+cat <<PEER_REVIEW1 > review1
+Subject: setup review 1 for bab
+In-Reply-To: <${PEER1_ID::-1}1@localhost.localdomain>
+
+Looks good to me
+
+Acked-by: bob <bob@localhost.localdomain>
+PEER_REVIEW1
+
+git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to bab@localhost.localdomain review1
+rm review1
+
+# end peer review 1
+
+# submit peer review 2
+
+cat <<PEER_REVIEW2 > review2
+Subject: setup review 2 for bib
+In-Reply-To: <${PEER2_ID::-1}2@localhost.localdomain>
+
+Looks good to me
+
+Acked-by: bob <bob@localhost.localdomain>
+PEER_REVIEW2
+
+git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to bib@localhost.localdomain review2
+rm review2
+
+# end peer review 2
+
+# end bob peer review
+popd
+sleep 1
+
+# bob env setup
+
+pushd submissions
+git config user.name bob
+git config user.email bob@localhost.localdomain
+git config sendemail.smtpUser bob
+git config sendemail.smtpPass builder
+git config sendemail.smtpserver localhost.localdomain
+git config sendemail.smtpserverport 465
+git config sendemail.smtpencryption ssl
+popd
+
+# bob make final submission
+
+# good final patchset
+pushd submissions
+git checkout --orphan setup_final_bob_good
+git rm -rf ./*
+mkdir -p bob/setup
+
+echo "abc" > bob/setup/work
+git add bob/setup/work
+git commit -sm 'add abc to work'
+
+echo "def" >> bob/setup/work
+git add bob/setup/work
+git commit -sm 'add def to work'
+
+git format-patch --cover-letter -v2 -2
+sed -i 's/\*\*\* SUBJECT HERE \*\*\*/Good patchset final/g' v2-0000-cover-letter.patch
+sed -i 's/\*\*\* BLURB HERE \*\*\*/Good patchset final/g' v2-0000-cover-letter.patch
+
+git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
+rm ./*.patch
+popd
+sleep 1
+
+# end bob final submission
+
+# bib env setup
+
+pushd submissions
+git config user.name bib
+git config user.email bib@localhost.localdomain
+git config sendemail.smtpUser bib
+git config sendemail.smtpPass builder
+git config sendemail.smtpserver localhost.localdomain
+git config sendemail.smtpserverport 465
+git config sendemail.smtpencryption ssl
+popd
+
+# bib final submission labeled RFC
+pushd submissions
+git checkout --orphan setup_final_bib_rfc
+git rm -rf ./*
+mkdir -p bib/setup
+
+echo "abc" > bib/setup/work
+git add bib/setup/work
+git commit -sm 'add abc to work'
+
+echo "def" >> bib/setup/work
+git add bib/setup/work
+git commit -sm 'add def to work'
+
+git format-patch --rfc --cover-letter -v1 -2
+sed -i 's/\*\*\* SUBJECT HERE \*\*\*/bib: RFC patchset/g' v1-0000-cover-letter.patch
+sed -i 's/\*\*\* BLURB HERE \*\*\*/bib: RFC patchset/g' v1-0000-cover-letter.patch
+
+git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
+rm ./*.patch
+popd
+sleep 1
+
+# end of bib final submission labeled RFC
+
+
+# bab env setup
+
+pushd submissions
+git config user.name bab
+git config user.email bab@localhost.localdomain
+git config sendemail.smtpUser bab
+git config sendemail.smtpPass builder
+git config sendemail.smtpserver localhost.localdomain
+git config sendemail.smtpserverport 465
+git config sendemail.smtpencryption ssl
+popd
+
+
+# bab final submission in wrong directory
+pushd submissions
+git checkout --orphan setup_final_bab_illegal
+git rm -rf ./*
+mkdir -p bib/setup
+
+echo "abc" > work
+git add work
+git commit -sm 'add abc to work'
+
+echo "def" >> work
+git add work
+git commit -sm 'add def to work'
+
+git format-patch --rfc --cover-letter -v1 -2
+sed -i 's/\*\*\* SUBJECT HERE \*\*\*/bab: Illegal patchset/g' v1-0000-cover-letter.patch
+sed -i 's/\*\*\* BLURB HERE \*\*\*/bab: Illegal patchset/g' v1-0000-cover-letter.patch
+
+git send-email --confirm=never --smtp-ssl-cert-path="$WORKDIR"/certs/fullchain.pem --to setup@localhost.localdomain ./*.patch
+rm ./*.patch
+popd
+sleep 1
+
+# end of bab final submission in wrong directory
+
+
+echo "wait for final submission deadline (10 secs)"
+sleep 10
+
+pushd grading
+git fetch --tag
+sleep 2
+git fetch -f origin refs/notes/*:refs/notes/*
+git remote set-url --push origin http://localhost:"$(get_git_port)"/cgi-bin/git-receive-pack/grading.git
+git notes --ref=grade add setup_final_bob -m '66'
+git notes --ref=grade add setup_review1_bob -m '22'
+git notes --ref=grade add setup_review2_bob -m '99'
+git notes --ref=feedback add setup_final_bob -m 'Good effort but try harder next time.'
+
+git notes --ref=grade add setup_final_bib -m '100'
+git notes --ref=feedback add setup_final_bib -m 'Perfect. But no peer review!'
+
+git notes --ref=feedback add setup_final_bab -m 'Please review git'
+
+git push origin refs/notes/*:refs/notes/*
+
+echo "$WORKDIR"

--- a/test-sub2.sh
+++ b/test-sub2.sh
@@ -1,0 +1,154 @@
+#!/bin/bash
+
+# test a bunch of rubric violations
+
+source test-lib
+
+setup_submissions_and_grading_repo
+
+cat << EOF > "$WORKDIR"/coding_rubric
+[{('--- /dev/null', '+++ b/user/coding/program.c'): 0},
+{('--- a/user/coding/program.c', '+++ b/user/coding/program.c'): 0},
+{('--- /dev/null', '+++ b/user/coding/Makefile'): 0}]
+EOF
+
+create_lighting_assignment coding 25 28 30  "$WORKDIR"/coding_rubric
+
+setup_submissions_for bob
+
+enter_and_checkout coding_initial_bob_toomany
+write_commit_to "C program" bob/coding/program.c
+write_commit_to "More C program" bob/coding/program.c "append"
+write_commit_to "Yet more C program" bob/coding/program.c "append"
+write_commit_to "Makefile content" bob/coding/Makefile
+git format-patch -v1 --cover-letter --rfc -4
+fixup_cover "Too many patches"
+exit_after_sending coding
+
+enter_and_checkout coding_initial_bob_toofew
+write_commit_to "C program" bob/coding/program.c
+write_commit_to "Makefile content" bob/coding/Makefile
+git format-patch -v1 --cover-letter --rfc -2
+fixup_cover "Too few patches"
+exit_after_sending coding
+
+enter_and_checkout coding_initial_bob_top-level-first
+write_commit_to "C program" program.c
+write_commit_to "More C program" bob/coding/program.c "append"
+write_commit_to "Makefile content" Makefile
+git format-patch -v1 --cover-letter --rfc -3
+fixup_cover "Top level first file patches"
+exit_after_sending coding
+
+enter_and_checkout coding_initial_bob_top-level-third
+write_commit_to "C program" bob/coding/program.c
+write_commit_to "More C program" bob/coding/program.c "append"
+write_commit_to "Makefile content" Makefile
+git format-patch -v1 --cover-letter --rfc -3
+fixup_cover "Top level third file patches"
+exit_after_sending coding
+
+enter_and_checkout coding_initial_bob_second-level-first
+write_commit_to "C program" bob/program.c
+write_commit_to "More C program" bob/program.c "append"
+write_commit_to "Makefile content" bob/coding/Makefile
+git format-patch -v1 --cover-letter --rfc -3
+fixup_cover "Second level first file patches"
+exit_after_sending coding
+
+enter_and_checkout coding_initial_bob_second-level-third
+write_commit_to "C program" bob/coding/program.c
+write_commit_to "More C program" bob/coding/program.c "append"
+write_commit_to "Makefile content" bob/Makefile
+git format-patch -v1 --cover-letter --rfc -3
+fixup_cover "Second level third file patches"
+exit_after_sending coding
+
+enter_and_checkout coding_initial_bob_fourth-level-first
+write_commit_to "C program" bob/coding/program/program.c
+write_commit_to "More C program" bob/coding/program/program.c "append"
+write_commit_to "Makefile content" bob/coding/Makefile
+git format-patch -v1 --cover-letter --rfc -3
+fixup_cover "Fourth level first file patches"
+exit_after_sending coding
+
+enter_and_checkout coding_initial_bob_fourth-level-third
+write_commit_to "C program" bob/coding/program.c
+write_commit_to "More C program" bob/coding/program.c "append"
+write_commit_to "Makefile content" bob/coding/program/Makefile
+git format-patch -v1 --cover-letter --rfc -3
+fixup_cover "Fourth level third file patches"
+exit_after_sending coding
+
+enter_and_checkout coding_initial_bob_wrong-second-dir-first
+write_commit_to "C program" bob/setup/program.c
+write_commit_to "More C program" bob/setup/program.c "append"
+write_commit_to "Makefile content" bob/coding/Makefile
+git format-patch -v1 --cover-letter --rfc -3
+fixup_cover "Wrong second directory first patches"
+exit_after_sending coding
+
+enter_and_checkout coding_initial_bob_wrong-second-dir-third
+write_commit_to "C program" bob/coding/program.c
+write_commit_to "More C program" bob/coding/program.c "append"
+write_commit_to "Makefile content" bob/setup/Makefile
+git format-patch -v1 --cover-letter --rfc -3
+fixup_cover "Wrong second directory third patches"
+exit_after_sending coding
+
+enter_and_checkout coding_initial_bob_wrong-filename-first
+write_commit_to "C program" bob/coding/hello.c
+write_commit_to "More C program" bob/coding/hello.c "append"
+write_commit_to "Makefile content" bob/coding/Makefile
+git format-patch -v1 --cover-letter --rfc -3
+fixup_cover "Wrong filename first patches"
+exit_after_sending coding
+
+enter_and_checkout coding_initial_bob_wrong-filename-third
+write_commit_to "C program" bob/coding/program.c
+write_commit_to "More C program" bob/coding/program.c "append"
+write_commit_to "Makefile content" bob/coding/Snakefile
+git format-patch -v1 --cover-letter --rfc -3
+fixup_cover "Wrong filename third patches"
+exit_after_sending coding
+
+enter_and_checkout coding_initial_bob_good
+write_commit_to "C program" bob/coding/program.c
+write_commit_to "More C program" bob/coding/program.c "append"
+write_commit_to "Makefile content" bob/coding/Makefile
+git format-patch -v1 --cover-letter --rfc -3
+fixup_cover "Good patches"
+exit_after_sending coding
+
+pushd "$WORKDIR"
+git clone http://localhost:"$(get_git_port)"/grading.git
+pushd grading
+
+STATUSES=(
+"patch count 4 violates expected rubric patch count of 3!"
+"patch count 2 violates expected rubric patch count of 3!"
+"illegal patch 1: permission denied for path program.c!"
+"illegal patch 3: permission denied for path Makefile!"
+"patch 1 violates the assignment rubric!"
+"patch 3 violates the assignment rubric!"
+"patch 1 violates the assignment rubric!"
+"patch 3 violates the assignment rubric!"
+"patch 1 violates the assignment rubric!"
+"patch 3 violates the assignment rubric!"
+"patch 1 violates the assignment rubric!"
+"patch 3 violates the assignment rubric!"
+"patchset applies."
+)
+
+# submitted patchses should have statuses in this order
+# assumption: first ID tag is first patch submitted by this script and IDs increase monotonically
+i=0
+for t in $(git tag); do
+	git show -s --oneline "$t" | grep -q "${STATUSES[$i]}"
+	i=$((i+1))
+done
+popd
+popd
+
+echo "RUBRIC CHECKS PASS"
+echo "$WORKDIR"

--- a/test-sub3.sh
+++ b/test-sub3.sh
@@ -1,0 +1,48 @@
+#!/bin/bash
+
+# test only initial submission results in automatic 0
+
+source test-lib
+
+setup_submissions_and_grading_repo
+
+create_lighting_assignment fun 5 7 10
+
+setup_submissions_for bob
+
+enter_and_checkout fun_initial_bob_only-initial
+write_commit_to "C program" bob/fun/program.c
+write_commit_to "More C program" bob/fun/program.c "append"
+write_commit_to "Yet more C program" bob/fun/program.c "append"
+git format-patch -v1 --cover-letter --rfc -3
+fixup_cover "Only initial sub patchset"
+exit_after_sending fun
+
+# wait for initial submission deadline
+sleep 9
+
+setup_testdir
+
+# login as bob
+curl --url "https://$SINGULARITY_HOSTNAME/login" \
+  --unix-socket ./socks/https.sock \
+  "${CURL_OPTS[@]}" \
+  -c test/cookies \
+  --data "username=bob&password=builder" \
+  | tee test/login_success \
+  | grep "msg = bob authenticated by password"
+
+
+# check for fun assignment and save dashboard
+curl --url "https://$SINGULARITY_HOSTNAME/dashboard" \
+  --unix-socket ./socks/https.sock \
+  -b test/cookies \
+  "${CURL_OPTS[@]}" \
+  | tee test/dashboard \
+  | grep "fun"
+
+grep "patchset applies." test/dashboard
+grep "No submission" test/dashboard
+grep "Total Score: 0.0" test/dashboard
+
+echo "INITIAL SUBMISSION ONLY GETS AUTO ZERO CONFIRMED"

--- a/test.sh
+++ b/test.sh
@@ -2,14 +2,6 @@
 
 # Testing script for singularity and orbit
 
-# This line:
-# - aborts the script after any pipeline returns nonzero (e)
-# - shows all commands as they are run (x)
-# - sets any dereference of an unset variable to trigger an error (u)
-# - causes the return value of a pipeline to be the nonzero return value
-#   of the furthest right failing command or zero if no command failed (o pipefail)
-set -exuo pipefail
-
 source test-lib
 
 require() { command -v "$1" > /dev/null || { echo "error: $1 command required yet absent" ; exit 1 ; } ; }

--- a/test.sh
+++ b/test.sh
@@ -10,15 +10,15 @@
 #   of the furthest right failing command or zero if no command failed (o pipefail)
 set -exuo pipefail
 
-DOCKER=${DOCKER:-podman}
-DOCKER_COMPOSE=${DOCKER_COMPOSE:-podman-compose}
+PODMAN=${PODMAN:-podman}
+PODMAN_COMPOSE=${PODMAN_COMPOSE:-podman-compose}
 
 require() { command -v "$1" > /dev/null || { echo "error: $1 command required yet absent" ; exit 1 ; } ; }
 require curl
 require jq
 require flake8
-require "${DOCKER}"
-require "${DOCKER_COMPOSE}"
+require "${PODMAN}"
+require "${PODMAN_COMPOSE}"
 
 # Check for shell script style compliance with shellcheck
 ./script-lint.sh
@@ -40,7 +40,7 @@ exec jq -r -n "env.SINGULARITY_HOSTNAME"
 
 SINGULARITY_HOSTNAME=${SINGULARITY_HOSTNAME:-"${HOSTNAME_FROM_DOTENV}"}
 
-${DOCKER} cp singularity_nginx_1:/etc/ssl/nginx/fullchain.pem test/ca_cert.pem
+${PODMAN} cp singularity_nginx_1:/etc/ssl/nginx/fullchain.pem test/ca_cert.pem
 
 CURL_OPTS=( \
 --verbose \
@@ -150,10 +150,10 @@ curl --url "pop3s://$SINGULARITY_HOSTNAME" \
 orbit/warpdrive.sh -u resu -p ssap -n
 
 # Limit `resu`'s access to the empty inbox
-${DOCKER_COMPOSE} exec denis /usr/local/bin/restrict_access /var/lib/email/journal/journal -d resu
+${PODMAN_COMPOSE} exec denis /usr/local/bin/restrict_access /var/lib/email/journal/journal -d resu
 
 # Update list of email to include new message
-${DOCKER_COMPOSE} exec denis /usr/local/bin/init_journal /var/lib/email/journal/journal /var/lib/email/journal/temp /var/lib/email/mail
+${PODMAN_COMPOSE} exec denis /usr/local/bin/init_journal /var/lib/email/journal/journal /var/lib/email/journal/temp /var/lib/email/mail
 
 # Check that the user can get the most recent message sent to the server
 curl --url "pop3s://$SINGULARITY_HOSTNAME/1" \
@@ -173,7 +173,7 @@ curl --url "pop3s://$SINGULARITY_HOSTNAME" \
 
 
 # Remove limit on `resu`'s access to the inbox
-${DOCKER_COMPOSE} exec denis /usr/local/bin/restrict_access /var/lib/email/journal/journal -a resu
+${PODMAN_COMPOSE} exec denis /usr/local/bin/restrict_access /var/lib/email/journal/journal -a resu
 
 # Check that `resu` can now get the most recent message sent to the server
 curl --url "pop3s://$SINGULARITY_HOSTNAME/1" \

--- a/test.sh
+++ b/test.sh
@@ -10,8 +10,7 @@
 #   of the furthest right failing command or zero if no command failed (o pipefail)
 set -exuo pipefail
 
-PODMAN=${PODMAN:-podman}
-PODMAN_COMPOSE=${PODMAN_COMPOSE:-podman-compose}
+source test-lib
 
 require() { command -v "$1" > /dev/null || { echo "error: $1 command required yet absent" ; exit 1 ; } ; }
 require curl
@@ -26,28 +25,7 @@ require "${PODMAN_COMPOSE}"
 # Check python style compliance
 flake8
 
-# Create test dir if it does not exist yet
-mkdir -p test
-
-# Reset the test directory
-rm -f test/*
-
-HOSTNAME_FROM_DOTENV="$(sh -c '
-set -o allexport
-. ./.env
-exec jq -r -n "env.SINGULARITY_HOSTNAME"
-')"
-
-SINGULARITY_HOSTNAME=${SINGULARITY_HOSTNAME:-"${HOSTNAME_FROM_DOTENV}"}
-
-${PODMAN} cp singularity_nginx_1:/etc/ssl/nginx/fullchain.pem test/ca_cert.pem
-
-CURL_OPTS=( \
---verbose \
---cacert test/ca_cert.pem \
---fail \
---no-progress-meter \
-)
+setup_testdir
 
 # Check that registration fails before user creation
 curl --url "https://$SINGULARITY_HOSTNAME/register" \


### PR DESCRIPTION
Bring back automated feedback

Before due date: show accepted/issues/rejected

After due date: show full status string generated by mailman/patchset.py

Show final submission, review, and total scores on dashboard based on git notes

Framework for automated tests by denis on initial and final tag promotion and a couple of checks

Fixes #255 
Fixes #258 
Fixes #259 
Fixes #260 
Fixes #232
Fixes #206
Fixes #111
Fixes #110
Fixes #200 
Fixes #262 
Fixes #257
Fixes #207 
Fixes #202 
Fixes #145 
Fixes #109 

For the change that adds the warning msg when denis is dirty: it could print the time it was dirtied using the /tmp/dirty modification time. Not sure how useful it would be but it would be trivial to implement

Patchsets modifying files outside of student directory are detected by scanning the signed off by line and are rejected if:
1) there is no signed off by line
2) the patches modify anything outside of submissions/foo where the signed off by line looks like Signed-off-by: 
foo-bar <foo@$COURSE_DOMAIN>