### PR TITLE
CI: rename yaml file and job to reflect reality

### DIFF
--- a/.github/workflows/PINP-test.yaml
+++ b/.github/workflows/PINP-test.yaml
@@ -1,4 +1,4 @@
-name: Circumference Test Container CI
+name: Singularity PINP CI
 
 on:
   push:


### PR DESCRIPTION
Circumference has not been involved in singularity CI since commit 930b740 ("CI: move code into singularity repo") so lets rename