### PR TITLE
Denis enhanced

### DIFF
--- a/container-compose.yml
+++ b/container-compose.yml
@@ -185,6 +185,7 @@ services:
         - orbit_source=./orbit
     environment:
       TZ: ${SINGULARITY_TIMEZONE}
+      SINGULARITY_HOSTNAME: ${SINGULARITY_HOSTNAME}
     volumes:
       - type: volume
         source: denis-db

--- a/denis/final.py
+++ b/denis/final.py
@@ -5,12 +5,12 @@ import utilities
 
 assignment = sys.argv[1]
 
-utilities.release_subs([sub for sub in
-                        utilities.user_to_sub(assignment, 'final').values()
-                        if sub])
+usernames_to_subs = utilities.user_to_sub(assignment, 'final')
+
+utilities.release_subs([sub.submission_id for sub in usernames_to_subs.values() if sub])
 
 print(f'final subs for {assignment} released')
 
 tags = utilities.update_tags(assignment, 'final')
 
-utilities.run_automated_checks(tags)
+utilities.run_automated_checks(tags, usernames_to_subs)

--- a/denis/initial.py
+++ b/denis/initial.py
@@ -13,8 +13,8 @@ assignment = sys.argv[1]
 
 usernames_to_subs = utilities.user_to_sub(assignment, 'initial')
 
-students_who_submitted = [username for username, sub_id in
-                          usernames_to_subs.items() if sub_id is not None]
+students_who_submitted = [username for username, sub in
+                          usernames_to_subs.items() if sub is not None]
 
 # restrict future email access for students who didnt make an initial sub
 for student, sub_id in usernames_to_subs.items():
@@ -54,10 +54,10 @@ except db.peewee.IntegrityError as e:
     print(e)
 
 
-utilities.release_subs([sub for sub in usernames_to_subs.values() if sub])
+utilities.release_subs([sub.submission_id for sub in usernames_to_subs.values() if sub])
 
 print(f'initial subs for {assignment} released')
 
 tags = utilities.update_tags(assignment, 'initial')
 
-utilities.run_automated_checks(tags)
+utilities.run_automated_checks(tags, usernames_to_subs)

--- a/denis/peer_review.py
+++ b/denis/peer_review.py
@@ -7,8 +7,8 @@ assignment = sys.argv[1]
 
 ids = []
 
-ids += [sub for sub in utilities.user_to_sub(assignment, 'review1').values() if sub]
-ids += [sub for sub in utilities.user_to_sub(assignment, 'review2').values() if sub]
+ids += [sub.submission_id for sub in utilities.user_to_sub(assignment, 'review1').values() if sub]
+ids += [sub.submission_id for sub in utilities.user_to_sub(assignment, 'review2').values() if sub]
 
 utilities.release_subs(ids)
 

--- a/denis/utilities.py
+++ b/denis/utilities.py
@@ -23,7 +23,7 @@ def user_to_sub(assignment, component):
         sub = (relevant_gradeables
                .where(grd_tbl.user == username)
                .first())
-        submission_ids[user.username] = sub.submission_id if sub else None
+        submission_ids[user.username] = sub if sub else None
 
     return submission_ids
 
@@ -80,7 +80,29 @@ def update_tags(assignment, component):
     return updated_tags
 
 
-def run_automated_checks(tags):
+def check_corrupt_or_missing(repo, tag, username_to_subs):
+    [assignment, component, user] = tag.split('_')
+
+    gradable = username_to_subs[user]
+
+    msg = 'corruption and existence check'
+    msg += '\n'
+    msg += '------------------------------'
+    msg += '\n\n'
+    if not gradable or gradable.status[-1] == '!':
+        repo.git.execute(['git', 'notes', '--ref=grade', 'add', tag, '-m', '0'])
+        if not gradable:
+            msg += 'automatic 0 due to missing submission!'
+        else:
+            msg += 'automatic 0 due to corrupt submission!'
+    else:
+        msg += 'Patchset applies.'
+
+    msg += '\n\n'
+    return msg
+
+
+def run_automated_checks(tags, username_to_subs):
     with tempfile.TemporaryDirectory() as repo_path:
         repo = git.Repo.clone_from(PULL_URL, repo_path)
 
@@ -90,6 +112,8 @@ def run_automated_checks(tags):
 
         for tag in tags:
             msg = 'Automated tests by denis'
+            msg += '\n\n'
+            msg += check_corrupt_or_missing(repo, tag, username_to_subs)
             repo.git.execute(['git', 'notes', '--ref=denis', 'add', tag, '-m', msg])
 
         remote.push('refs/notes/*:refs/notes/*')


### PR DESCRIPTION
Since commit 22c9694 ("denis: add notes tied to initial and final submissions"), denis can now add notes to tagged submissions on the initial and final submission deadlines. We can build on this scaffolding to implement the first automated grading features. In this PR, I've included an initial set of three: automatic zero for corrupt or missing patchsets, DCO check, and subject tag format check. More to come.

Fixes https://github.com/underground-software/singularity/issues/207
Fixes https://github.com/underground-software/singularity/issues/110
Fixes https://github.com/underground-software/singularity/issues/262