### PR TITLE
standardize query order_by argument

### DIFF
--- a/denis/utilities.py
+++ b/denis/utilities.py
@@ -47,7 +47,7 @@ def configure_repo(repo):
 def update_tags(assignment, component):
     grd_tbl = mailman.db.Gradeable
     subs = (grd_tbl.select()
-                   .order_by(-grd_tbl.timestamp)
+                   .order_by(grd_tbl.timestamp.desc())
                    .where(grd_tbl.assignment == assignment)
                    .where(grd_tbl.component == component))
     with tempfile.TemporaryDirectory() as repo_path:

--- a/mailman/inspector.py
+++ b/mailman/inspector.py
@@ -56,7 +56,7 @@ def main():
 
 
 def submissions(assignment, username):
-    query = db.Submission.select().order_by(-db.Submission.timestamp)
+    query = db.Submission.select().order_by(db.Submission.timestamp.desc())
     if assignment:
         query = query.where(db.Submission.recipient == assignment)
     if username:
@@ -68,7 +68,7 @@ def submissions(assignment, username):
 
 
 def gradables(assignment, username, component):
-    query = db.Gradeable.select().order_by(-db.Gradeable.timestamp)
+    query = db.Gradeable.select().order_by(db.Gradeable.timestamp.desc())
     if assignment:
         query = query.where(db.Gradeable.assignment == assignment)
     if username:

--- a/orbit/radius.py
+++ b/orbit/radius.py
@@ -390,7 +390,7 @@ def handle_activity(rocket):
 
     submissions = (mailman.db.Submission.select()
                    .where(mailman.db.Submission.user == rocket.session.username)
-                   .order_by(- mailman.db.Submission.timestamp))
+                   .order_by(mailman.db.Submission.timestamp.desc()))
 
     def submission_fields(sub):
         return (datetime.fromtimestamp(sub.timestamp).astimezone().isoformat(),


### PR DESCRIPTION
To sort the results of a query with peewee orm, in descending order, we pass a column label to the order_by() method on a select() call and either prefix it with the '-' symbol or call tis.desc() method.

Currently we do some of both. Change all order_by({-X} => {X.desc()}) to make the code easier to read and more consistent.