### PR TITLE
denis/configure: inform user when dumping dirty

### DIFF
--- a/denis/config.py
+++ b/denis/config.py
@@ -1,0 +1,1 @@
+RELOAD_FILE = '/tmp/denis_reload_file'

--- a/denis/db.py
+++ b/denis/db.py
@@ -1,7 +1,8 @@
 #!/usr/bin/env python3
 import peewee
 
-DB = peewee.SqliteDatabase("/var/lib/denis/assignments.db")
+DB_PATH = '/var/lib/denis/assignments.db'
+DB = peewee.SqliteDatabase(DB_PATH)
 
 
 class BaseModel(peewee.Model):

--- a/denis/start.py
+++ b/denis/start.py
@@ -6,6 +6,7 @@ import subprocess
 import sys
 
 import db
+import config
 
 from configure import far_future
 
@@ -61,6 +62,9 @@ def main():
     signal.signal(signal.SIGTERM, signal_handler)
     signal.signal(signal.SIGUSR1, signal_handler)
     signal.signal(signal.SIGRTMIN, signal_handler)
+
+    # create reload file
+    open(config.RELOAD_FILE, 'w').close()
 
     again = True
     while again:


### PR DESCRIPTION
When the assignment database is altered, the due date waiters must be restarted in order for the new due dates to be operative using:

$ denis/configure.sh reload

Currently there is no way to know that one has forgotten to run this command. Add a warning message to the output of:

$ denis/configure.sh dump

to indicate when one has altered the database but not yet operationalized their intentions.

Fixes #257