### PR TITLE
Script lint improvements

### DIFF
--- a/script-lint.sh
+++ b/script-lint.sh
@@ -22,3 +22,5 @@ shellcheck git/hooks/post-update
 # -x needed to make shellcheck follow `source` command
 shellcheck -x backup/backup.sh
 shellcheck -x backup/restore.sh
+
+test "$(git ls-tree -r HEAD | grep -c '.*\.sh$')" -eq "13" || (echo "New script detected. Does it need to be added to script-lint?" && false)


### PR DESCRIPTION
I was fiddling with orbit start.sh when I got nerd sniped by the fact that we don't lint it and in fact there are several scripts that we added but forgot to lint. Restore order to the universe by adding them all, and try to make it harder to forget to add linting in the future.