### PR TITLE
denis: check for DCO with full name (not username)

### DIFF
--- a/denis/utilities.py
+++ b/denis/utilities.py
@@ -107,13 +107,18 @@ def check_signed_off_by(repo, tag):
     [_, _, user] = tag.split('_', 2)
     hostname = os.getenv("SINGULARITY_HOSTNAME")
 
+    usr_tbl = orbit.db.User
+    fullname = (usr_tbl.select()
+                       .where(usr_tbl.username == user)
+                       .first()).fullname
+
     msg = 'signed off by check'
     msg += '\n'
     msg += '-------------------'
     msg += '\n\n'
 
     commits = repo.git.execute(['git', 'rev-list', '--reverse', tag]).split('\n')
-    expected_dco = f'Signed-off-by: {user} <{user}@{hostname}>'
+    expected_dco = f'Signed-off-by: {fullname} <{user}@{hostname}>'
     nr_flawless = 0
     for i, commit in enumerate(commits):
         patch = repo.git.execute(['git', 'show', commit])

--- a/test-lib
+++ b/test-lib
@@ -116,7 +116,7 @@ setup_submissions_for() {
 	local user="$1"
 
 	pushd "$SCRIPT_DIR"
-	orbit/warpdrive.sh -u "$user" -p builder -n || orbit/warpdrive.sh -u "$user" -p builder -m
+	orbit/warpdrive.sh -u "$user" -f "$user" -p builder -n || orbit/warpdrive.sh -u "$user" -f "$user" -p builder -m
 	popd
 
 	pushd "$WORKDIR"/submissions


### PR DESCRIPTION
Per the configuration provided to students by the containerfile served by orbit, the expected format of the signed-off-by line in student submissions is:
```
	Signed-off-by: $fullname <$username@$domain>
```
Not:
```
	Signed-off-by: $username <$username@$domain>
```

Pull the fullname from orbit.db in denis' check for the signed off by line and check for the correct format.

Fixes #289